### PR TITLE
Add quiet Instagram link in Mon approche (#17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy to `.env.local` and fill in values. Vite only exposes variables prefixed with `VITE_`.
+# https://vitejs.dev/guide/env-and-mode.html
+
+VITE_GOOGLE_MAPS_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ node_modules
 dist
 .DS_Store
 *.local
+
+# Secrets / local env (never commit real keys)
 .env
-.env.*
+.env.local
+.env.*.local

--- a/index.html
+++ b/index.html
@@ -383,6 +383,14 @@
                   durables demandent du temps et de la constance. Mon rôle est de t'accompagner de façon soutenue pour
                   t'aider à obtenir des résultats concrets.
                 </p>
+                <a
+                  class="mission-instagram-link"
+                  href="https://www.instagram.com/eliane.au.naturel"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Découvre mon quotidien sur Instagram (nouvel onglet)"
+                  >Découvre mon quotidien sur Instagram<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
+                >
               </div>
               <div class="mission-photo">
                 <div class="mission-photo-frame">

--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
                   t'aider à obtenir des résultats concrets.
                 </p>
                 <a
-                  class="mission-instagram-link"
+                  class="arrow-text-link mission-instagram-link"
                   href="https://www.instagram.com/eliane.au.naturel"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -414,20 +414,92 @@
         <div class="section-inner">
           <div class="presentiel-block reveal" data-reveal>
             <h2>Pourquoi le <em>présentiel</em></h2>
-            <p class="presentiel-lead">
-              Mon service repose sur un accompagnement personnalisé avec des séances en présentiel.
+            <p class="presentiel-intro">
+              Parce que la façon dont on s'entraîne change tout. Voici ce que le présentiel t'offre que rien d'autre ne
+              peut remplacer.
             </p>
-            <p class="presentiel-text">
-              Le présentiel permet de mieux apprendre les bonnes techniques, de diminuer les risques de blessure et
-              d'aller plus loin dans l'effort que si tu étais seule.
+            <div class="presentiel-mid">
+              <div class="presentiel-benefits" role="list">
+                <article class="presentiel-benefit-cell" role="listitem">
+                  <i class="presentiel-benefit__icon" data-lucide="eye" aria-hidden="true"></i>
+                  <h3 class="presentiel-benefit__title">Correction en temps réel</h3>
+                  <p class="presentiel-benefit__text">
+                    Ta technique s'ajuste en direct — tu progresses plus vite, sans ancrer de mauvaises habitudes.
+                  </p>
+                </article>
+                <article class="presentiel-benefit-cell" role="listitem">
+                  <i class="presentiel-benefit__icon" data-lucide="shield-check" aria-hidden="true"></i>
+                  <h3 class="presentiel-benefit__title">Progression sécuritaire</h3>
+                  <p class="presentiel-benefit__text">
+                    Les charges lourdes et mouvements complexes exigent un œil expert — pas un écran.
+                  </p>
+                </article>
+                <article class="presentiel-benefit-cell" role="listitem">
+                  <i class="presentiel-benefit__icon" data-lucide="calendar-check" aria-hidden="true"></i>
+                  <h3 class="presentiel-benefit__title">Imputabilité réelle</h3>
+                  <p class="presentiel-benefit__text">
+                    Tu te présentes. Je suis là. Aucune excuse ne tient face à un vrai rendez-vous, pris en personne.
+                  </p>
+                </article>
+                <article class="presentiel-benefit-cell" role="listitem">
+                  <i class="presentiel-benefit__icon" data-lucide="activity" aria-hidden="true"></i>
+                  <h3 class="presentiel-benefit__title">Adaptation à ton état du jour</h3>
+                  <p class="presentiel-benefit__text">
+                    Ton énergie, ton stress, ton sommeil varient. Ton entraînement s'adapte — ça, aucune app ne fait.
+                  </p>
+                </article>
+              </div>
+              <aside class="presentiel-location-card" aria-label="Lieu d'entraînement">
+                <span class="eyebrow eyebrow--with-anchor presentiel-location-card__eyebrow">Où ça se passe</span>
+                <h3 class="presentiel-location-card__name">Biner Training</h3>
+                <p class="presentiel-location-card__address">
+                  220 Bd Crémazie O<br />
+                  Montréal (Québec) &nbsp;H2P 1C6
+                </p>
+                <div class="presentiel-location-card__map" data-presentiel-map-wrap>
+                  <a
+                    class="presentiel-location-card__map-link"
+                    href="https://maps.app.goo.gl/c1V1Re3Guj8ZF6mEA"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Ouvrir Biner Training sur Google Maps (nouvel onglet)"
+                  >
+                    <span
+                      class="presentiel-location-card__map-fallback"
+                      hidden
+                      data-presentiel-map-fallback
+                      aria-hidden="true"
+                      >Carte&nbsp;: ajoute <code>VITE_GOOGLE_MAPS_API_KEY</code> dans <code>.env.local</code> pour
+                      l’aperçu local.</span
+                    >
+                    <img
+                      class="presentiel-location-card__map-img"
+                      data-presentiel-static-map
+                      alt="Emplacement de Biner Training sur Google Maps"
+                      width="480"
+                      height="280"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  </a>
+                </div>
+                <div class="presentiel-location-card__links">
+                  <a
+                    class="arrow-text-link"
+                    href="https://maps.app.goo.gl/c1V1Re3Guj8ZF6mEA"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Voir sur Google Maps (nouvel onglet)"
+                    >Voir sur Google Maps<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
+                  >
+                </div>
+              </aside>
+            </div>
+            <p class="presentiel-closing">
+              <em
+                >Parce que tu mérites qu'on te voie évoluer, pas juste qu'on te suive sur un écran.</em
+              >
             </p>
-            <a
-              class="btn btn-primary presentiel-cta"
-              href="https://cal.com/elianelarre/appel-decouverte"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Appel découverte</a
-            >
           </div>
         </div>
       </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "eliane-site",
       "version": "1.0.0",
+      "dependencies": {
+        "lucide": "^1.8.0"
+      },
       "devDependencies": {
         "sharp": "^0.34.5",
         "vite": "^6.2.0"
@@ -1396,6 +1399,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/lucide": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.8.0.tgz",
+      "integrity": "sha512-JjV/QnadgFLj1Pyu9IKl0lknrolFEzo04B64QcYLLeRzZl/iEHpdbSrRRKbyXcv45SZNv+WGjIUCT33e7xHO6Q==",
+      "license": "ISC"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "devDependencies": {
     "sharp": "^0.34.5",
     "vite": "^6.2.0"
+  },
+  "dependencies": {
+    "lucide": "^1.8.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,61 @@
 import './style.css';
+import { createIcons } from 'lucide';
+import Eye from 'lucide/dist/esm/icons/eye.js';
+import ShieldCheck from 'lucide/dist/esm/icons/shield-check.js';
+import CalendarCheck from 'lucide/dist/esm/icons/calendar-check.js';
+import Activity from 'lucide/dist/esm/icons/activity.js';
 
 const BOOKING_HREF = 'https://cal.com/elianelarre/appel-decouverte';
+
+/** Biner Training — 220 Bd Crémazie O; center matches Google Maps place resolution for maps.app.goo.gl/c1V1Re3Guj8ZF6mEA */
+const BINER_STATIC_MAP_CENTER = '45.5385897,-73.6430173';
+
+function initPresentielLucideIcons() {
+  const root = document.getElementById('presentiel');
+  if (!root) return;
+  createIcons({
+    icons: { Eye, ShieldCheck, CalendarCheck, Activity },
+    attrs: {
+      width: 34,
+      height: 34,
+      'stroke-width': 1.5,
+    },
+    root,
+  });
+}
+
+function initPresentielStaticMap() {
+  const img = document.querySelector('[data-presentiel-static-map]');
+  if (!img) return;
+
+  const wrap = document.querySelector('[data-presentiel-map-wrap]');
+  const fallback = document.querySelector('[data-presentiel-map-fallback]');
+  const key = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
+  const showFallback = () => {
+    if (img.parentNode) img.remove();
+    wrap?.classList.add('presentiel-location-card__map--fallback');
+    fallback?.removeAttribute('hidden');
+  };
+
+  if (!key) {
+    showFallback();
+    return;
+  }
+
+  const url = new URL('https://maps.googleapis.com/maps/api/staticmap');
+  url.searchParams.set('center', BINER_STATIC_MAP_CENTER);
+  url.searchParams.set('zoom', '16');
+  url.searchParams.set('size', '480x280');
+  url.searchParams.set('markers', `size:mid|color:0x552772|${BINER_STATIC_MAP_CENTER}`);
+  url.searchParams.set('key', key);
+
+  const markLoaded = () => img.classList.add('is-loaded');
+  img.addEventListener('load', markLoaded);
+  img.addEventListener('error', showFallback);
+  img.src = url.toString();
+  if (img.complete && img.naturalWidth > 0) markLoaded();
+}
 
 /** @param {HTMLElement} nav */
 function initNav(nav) {
@@ -94,6 +149,9 @@ const nav = document.getElementById('site-nav');
 if (nav) initNav(nav);
 
 initReveal();
+
+initPresentielLucideIcons();
+initPresentielStaticMap();
 
 const faq = document.querySelector('[data-faq]');
 if (faq) initFaq(faq);

--- a/src/style.css
+++ b/src/style.css
@@ -1423,9 +1423,8 @@ button:focus-visible {
   color: var(--mid);
 }
 
-.mission-instagram-link {
+.arrow-text-link {
   display: inline-block;
-  margin-top: clamp(2rem, 4vw, 2.5rem);
   font-family: var(--font-sans);
   font-size: clamp(0.9375rem, 0.35vw + 0.9rem, 1rem);
   font-weight: 500;
@@ -1439,16 +1438,20 @@ button:focus-visible {
     text-decoration-thickness 0.2s ease;
 }
 
-.mission-instagram-link:hover {
+.mission-instagram-link {
+  margin-top: clamp(2rem, 4vw, 2.5rem);
+}
+
+.arrow-text-link:hover {
   color: var(--plum-hover);
   text-decoration-thickness: 2px;
 }
 
-.mission-instagram-link .hero-ghost-arrow {
+.arrow-text-link .hero-ghost-arrow {
   transition: transform 0.2s ease;
 }
 
-.mission-instagram-link:hover .hero-ghost-arrow {
+.arrow-text-link:hover .hero-ghost-arrow {
   transform: translateX(4px);
 }
 
@@ -1514,24 +1517,193 @@ button:focus-visible {
 }
 
 /* —— Pourquoi le présentiel —— */
-.presentiel-lead {
-  font-size: 1.0625rem;
-  line-height: 1.85;
-  color: var(--mid);
-  max-width: 42rem;
-  margin-bottom: 1rem;
+#presentiel.section {
+  padding-block: calc(var(--pad-y) - clamp(0.75rem, 1.5vw, 1rem));
 }
 
-.presentiel-text {
+.presentiel-intro {
   font-size: 1rem;
   line-height: 1.85;
   color: var(--mid);
-  max-width: 42rem;
-  margin-bottom: 0;
+  max-width: 40rem;
+  margin: 0 0 clamp(1.25rem, 3vw, 1.75rem);
 }
 
-.presentiel-cta {
-  margin-top: 1.75rem;
+.presentiel-mid {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: clamp(2.5rem, 4vw, 4rem);
+  align-items: start;
+}
+
+.presentiel-benefits {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+  margin: 0;
+  padding: 0;
+}
+
+.presentiel-benefit-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin: 0;
+  min-width: 0;
+}
+
+.presentiel-benefit__icon {
+  display: block;
+  flex-shrink: 0;
+  width: 2.125rem;
+  height: 2.125rem;
+  margin: 0 0 clamp(1rem, 2vw, 1.25rem);
+  color: var(--plum);
+  stroke-width: 1.5;
+}
+
+.presentiel-benefit__title {
+  font-family: var(--font-sans);
+  font-size: clamp(1.125rem, 0.8vw + 1rem, 1.375rem);
+  font-weight: 600;
+  font-style: normal;
+  line-height: 1.25;
+  color: var(--ink);
+  margin: 0 0 0.5rem;
+}
+
+.presentiel-benefit__text {
+  margin: 0;
+  font-size: clamp(0.9375rem, 0.2vw + 0.9rem, 1rem);
+  line-height: 1.5;
+  color: var(--mid);
+}
+
+.presentiel-location-card {
+  background: #fdfaf5;
+  border-radius: clamp(16px, 2vw, 24px);
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(85, 39, 114, 0.12);
+}
+
+.presentiel-location-card__eyebrow {
+  display: block;
+  margin: 0 0 clamp(0.5rem, 1vw, 0.65rem);
+}
+
+.presentiel-location-card__name {
+  font-family: var(--font-sans);
+  font-size: clamp(1.25rem, 1.5vw + 1rem, 1.5rem);
+  font-weight: 600;
+  font-style: normal;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 clamp(0.75rem, 1.2vw, 1rem);
+}
+
+.presentiel-location-card__address {
+  margin: 0 0 clamp(1.15rem, 2vw, 1.35rem);
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--mid);
+}
+
+.presentiel-location-card__map {
+  margin: 0 0 clamp(1.15rem, 2vw, 1.35rem);
+}
+
+.presentiel-location-card__map-link {
+  display: block;
+  border-radius: clamp(12px, 1.5vw, 16px);
+  overflow: hidden;
+  background: var(--beige-deep);
+  line-height: 0;
+}
+
+.presentiel-location-card__map-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 280px;
+  aspect-ratio: 480 / 280;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.presentiel-location-card__map-img.is-loaded {
+  opacity: 1;
+}
+
+.presentiel-location-card__map--fallback .presentiel-location-card__map-img {
+  display: none;
+}
+
+.presentiel-location-card__map--fallback .presentiel-location-card__map-fallback {
+  display: block;
+  padding: 1.5rem;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: var(--mid);
+  text-align: center;
+}
+
+.presentiel-location-card__map--fallback .presentiel-location-card__map-link {
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.presentiel-location-card__map-fallback code {
+  font-size: 0.8125rem;
+}
+
+.presentiel-location-card__links {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.presentiel-closing {
+  margin: clamp(3.25rem, 5vw, 4rem) 0 clamp(3rem, 4vw, 3.5rem);
+  max-width: none;
+}
+
+.presentiel-closing em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.375rem, 2.2vw, 1.75rem);
+  line-height: 1.45;
+  color: var(--plum);
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .presentiel-mid {
+    gap: 2.5rem;
+  }
+
+  .presentiel-closing em {
+    font-size: clamp(1.25rem, 2vw, 1.375rem);
+  }
+}
+
+@media (max-width: 767px) {
+  .presentiel-mid {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  .presentiel-benefits {
+    grid-template-columns: 1fr;
+  }
+
+  .presentiel-benefit__icon {
+    width: 2rem;
+    height: 2rem;
+  }
 }
 
 .poids-libres-list {
@@ -1992,19 +2164,19 @@ button:focus-visible {
     transform: none;
   }
 
-  .mission-instagram-link {
+  .arrow-text-link {
     transition: none;
   }
 
-  .mission-instagram-link:hover {
+  .arrow-text-link:hover {
     text-decoration-thickness: 1px;
   }
 
-  .mission-instagram-link .hero-ghost-arrow {
+  .arrow-text-link .hero-ghost-arrow {
     transition: none;
   }
 
-  .mission-instagram-link:hover .hero-ghost-arrow {
+  .arrow-text-link:hover .hero-ghost-arrow {
     transform: none;
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1423,6 +1423,35 @@ button:focus-visible {
   color: var(--mid);
 }
 
+.mission-instagram-link {
+  display: inline-block;
+  margin-top: clamp(2rem, 4vw, 2.5rem);
+  font-family: var(--font-sans);
+  font-size: clamp(0.9375rem, 0.35vw + 0.9rem, 1rem);
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--plum);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+  transition:
+    color 0.2s ease,
+    text-decoration-thickness 0.2s ease;
+}
+
+.mission-instagram-link:hover {
+  color: var(--plum-hover);
+  text-decoration-thickness: 2px;
+}
+
+.mission-instagram-link .hero-ghost-arrow {
+  transition: transform 0.2s ease;
+}
+
+.mission-instagram-link:hover .hero-ghost-arrow {
+  transform: translateX(4px);
+}
+
 .mission-photo {
   grid-column: 2;
   grid-row: 1;
@@ -1960,6 +1989,22 @@ button:focus-visible {
   }
 
   .hero-secondary-cta:hover .hero-ghost-arrow {
+    transform: none;
+  }
+
+  .mission-instagram-link {
+    transition: none;
+  }
+
+  .mission-instagram-link:hover {
+    text-decoration-thickness: 1px;
+  }
+
+  .mission-instagram-link .hero-ghost-arrow {
+    transition: none;
+  }
+
+  .mission-instagram-link:hover .hero-ghost-arrow {
     transform: none;
   }
 


### PR DESCRIPTION
Closes #17, closes #19

## Summary
- **#17 — Mon approche:** Lien texte discret vers Instagram (`arrow-text-link`), accessibilité nouvel onglet.
- **#19 — Présentiel:** Refonte en trois zones (intro, grille 2×2 avec icônes Lucide, carte lieu Biner + Static Maps `zoom=16` et marqueur `size:mid`), texte des bénéfices réécrit, lien Google Maps centré sous la carte. Dépendance `lucide` (vanilla). Fichiers d’exemple d’environnement (voir branche / commits infra si présents).

## How to verify
- `npm run build`
- **Mon approche:** lien Instagram sous le deuxième paragraphe.
- **Présentiel:** mise en page mid + carte, carte visible avec clé `VITE_GOOGLE_MAPS_API_KEY` dans `.env.local` ou variables Vercel.
