### PR TITLE
Nav: Offres desktop dropdown (placeholder routes)

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,32 @@
       <nav aria-label="Navigation principale">
         <ul class="nav-desktop">
           <li><a href="#introduction">Introduction</a></li>
-          <li><a href="#programme">Programme</a></li>
+          <li class="nav-dropdown" data-nav-dropdown>
+            <button
+              type="button"
+              class="nav-dropdown-trigger"
+              id="nav-offres-trigger"
+              data-nav-dropdown-trigger
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-controls="nav-offres-menu"
+            >
+              Offres
+            </button>
+            <div
+              class="nav-dropdown-panel"
+              id="nav-offres-menu"
+              data-nav-dropdown-panel
+              role="menu"
+              aria-labelledby="nav-offres-trigger"
+              hidden
+            >
+              <div class="nav-dropdown-panel__surface">
+                <a href="/offres/offre-1" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 1</a>
+                <a href="/offres/offre-2" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 2</a>
+              </div>
+            </div>
+          </li>
           <li><a href="#faq">FAQ</a></li>
         </ul>
       </nav>

--- a/src/main.js
+++ b/src/main.js
@@ -58,6 +58,156 @@ function initPresentielStaticMap() {
 }
 
 /** @param {HTMLElement} nav */
+function initNavDesktopDropdowns(nav) {
+  const roots = nav.querySelectorAll('[data-nav-dropdown]');
+  if (!roots.length) return;
+
+  const reduceMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  roots.forEach((root) => {
+    const trigger = root.querySelector('[data-nav-dropdown-trigger]');
+    const panel = root.querySelector('[data-nav-dropdown-panel]');
+    const items = /** @type {HTMLElement[]} */ ([...root.querySelectorAll('[data-nav-dropdown-item]')]);
+    if (!trigger || !panel || !items.length) return;
+
+    let leaveTimer = 0;
+
+    const clearLeaveTimer = () => {
+      if (leaveTimer) {
+        window.clearTimeout(leaveTimer);
+        leaveTimer = 0;
+      }
+    };
+
+    const isExpanded = () => trigger.getAttribute('aria-expanded') === 'true';
+
+    const finishClose = () => {
+      panel.setAttribute('hidden', '');
+    };
+
+    const open = () => {
+      clearLeaveTimer();
+      if (isExpanded()) return;
+      trigger.setAttribute('aria-expanded', 'true');
+      panel.removeAttribute('hidden');
+      requestAnimationFrame(() => {
+        root.classList.add('is-open');
+      });
+    };
+
+    const close = () => {
+      clearLeaveTimer();
+      if (!isExpanded()) return;
+      trigger.setAttribute('aria-expanded', 'false');
+      root.classList.remove('is-open');
+      if (reduceMotion()) {
+        finishClose();
+        return;
+      }
+      const onEnd = (e) => {
+        if (e.target !== panel) return;
+        panel.removeEventListener('transitionend', onEnd);
+        finishClose();
+      };
+      panel.addEventListener('transitionend', onEnd);
+      window.setTimeout(() => {
+        panel.removeEventListener('transitionend', onEnd);
+        if (!isExpanded()) finishClose();
+      }, 300);
+    };
+
+    const scheduleCloseFromPointerLeave = () => {
+      clearLeaveTimer();
+      leaveTimer = window.setTimeout(() => {
+        leaveTimer = 0;
+        if (!root.contains(document.activeElement)) close();
+      }, 200);
+    };
+
+    root.addEventListener('mouseenter', () => {
+      clearLeaveTimer();
+      open();
+    });
+    root.addEventListener('mouseleave', scheduleCloseFromPointerLeave);
+
+    trigger.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (isExpanded()) close();
+      else open();
+    });
+
+    trigger.addEventListener('keydown', (e) => {
+      if (e.key === ' ' || e.key === 'Spacebar') {
+        e.preventDefault();
+        if (isExpanded()) close();
+        else open();
+        return;
+      }
+      if (e.key === 'Escape') {
+        if (!isExpanded()) return;
+        e.preventDefault();
+        close();
+        trigger.focus();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (!isExpanded()) open();
+        requestAnimationFrame(() => items[0]?.focus());
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (!isExpanded()) open();
+        requestAnimationFrame(() => items[items.length - 1]?.focus());
+      }
+    });
+
+    items.forEach((item, index) => {
+      item.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          close();
+          trigger.focus();
+          return;
+        }
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          if (index >= items.length - 1) items[0]?.focus();
+          else items[index + 1]?.focus();
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          if (index === 0) trigger.focus();
+          else items[index - 1]?.focus();
+        }
+      });
+    });
+
+    document.addEventListener(
+      'pointerdown',
+      (e) => {
+        if (!isExpanded()) return;
+        if (root.contains(/** @type {Node} */ (e.target))) return;
+        close();
+      },
+      true,
+    );
+
+    document.addEventListener('focusin', (e) => {
+      if (!isExpanded()) return;
+      if (root.contains(/** @type {Node} */ (e.target))) return;
+      close();
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth <= 900) close();
+    });
+  });
+}
+
+/** @param {HTMLElement} nav */
 function initNav(nav) {
   const toggle = document.querySelector('[data-nav-toggle]');
   const panel = document.querySelector('[data-nav-panel]');
@@ -88,6 +238,8 @@ function initNav(nav) {
   window.addEventListener('resize', () => {
     if (window.innerWidth > 900) setOpen(false);
   });
+
+  initNavDesktopDropdowns(nav);
 
   // Ensure booking CTA links are consistent (sanity check in dev)
   document.querySelectorAll(`a[href="${BOOKING_HREF}"]`).forEach((a) => {

--- a/src/style.css
+++ b/src/style.css
@@ -155,6 +155,93 @@ button:focus-visible {
   color: var(--plum);
 }
 
+/* Desktop “Offres” dropdown (markup lives in .nav-desktop; hidden <901px with the rest) */
+.nav-dropdown {
+  position: relative;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+}
+
+.nav-dropdown-trigger {
+  font: inherit;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mid);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s;
+}
+
+.nav-dropdown-trigger:hover,
+.nav-dropdown-trigger[aria-expanded='true'] {
+  color: var(--plum);
+}
+
+.nav-dropdown-panel {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  z-index: 110;
+  min-width: 11rem;
+  padding-top: 0.35rem;
+  transform: translateX(-50%) translateY(-6px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    visibility 0.2s;
+}
+
+.nav-dropdown.is-open .nav-dropdown-panel {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+.nav-dropdown-panel[hidden] {
+  display: none !important;
+}
+
+.nav-dropdown-panel__surface {
+  padding: 0.35rem 0;
+  background: var(--white);
+  border: 1px solid rgba(85, 39, 114, 0.18);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 10px 28px rgba(26, 20, 16, 0.1);
+}
+
+.nav-dropdown-link {
+  display: block;
+  padding: 0.65rem 1.1rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mid);
+  transition:
+    color 0.2s,
+    background 0.2s;
+}
+
+.nav-dropdown-link:hover {
+  color: var(--plum);
+  background: rgba(85, 39, 114, 0.07);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-dropdown-panel {
+    transition: none;
+  }
+}
+
 .nav-cta {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Closes #23.

## Summary
- **Desktop nav:** Replaced the in-page **Programme** link with an **Offres** control that matches other desktop link styling (uppercase, letter-spacing, plum hover / open state).
- **Dropdown:** Hover opens and stays open over trigger + panel (bridge padding); panel uses white surface, plum-tint border/shadow, item hover wash. Open/close uses opacity/transform (disabled when `prefers-reduced-motion: reduce`).
- **Items:** "Offre 1" → `/offres/offre-1`, "Offre 2" → `/offres/offre-2` (placeholders until pages exist).
- **A11y / input:** `aria-expanded`, `aria-haspopup="menu"`, `aria-controls`; `role="menu"` / `menuitem`; Tab/Enter/Space on trigger; Escape closes; Arrow keys between trigger and items; pointer outside + focus leaving the subtree closes the menu. Resize to ≤900px closes the menu.
- **Mobile:** `.nav-mobile-panel` unchanged (still **Programme** → `#programme`).

## How verified
- `npm run build` — success.

Refs batch tracker #20.