### PR TITLE
Refine poids libres section editorial layout

### DIFF
--- a/conditions-utilisation/index.html
+++ b/conditions-utilisation/index.html
@@ -107,7 +107,90 @@
         <div class="legal-inner">
           <h1>Conditions d'utilisation</h1>
           <p class="legal-updated"><em>Dernière mise à jour : avril 2026</em></p>
-          <p>Cette page sera bientôt complétée avec les conditions d'utilisation officielles d'Éliane Larre.</p>
+
+          <p>
+            Bienvenue sur le site d'Éliane Larre. En utilisant ce site et les services offerts, tu acceptes les
+            conditions décrites ci-dessous. Prends le temps de les lire attentivement.
+          </p>
+
+          <h2>1. Services offerts</h2>
+          <p>
+            J'offre des services d'entraînement personnel privé en présentiel à Montréal, incluant la conception de
+            programmes personnalisés, le suivi, et des conseils en nutrition. Les détails spécifiques de chaque
+            accompagnement sont précisés dans un contrat ou une entente distincte remise lors de ton inscription.
+          </p>
+
+          <h2>2. Accès au site</h2>
+          <p>
+            L'accès à ce site est gratuit. Tu t'engages à utiliser le site conformément aux lois applicables et à ne pas
+            nuire à son bon fonctionnement.
+          </p>
+
+          <h2>3. Réservation et paiement</h2>
+          <p>
+            La réservation des séances se fait par l'entremise des moyens indiqués sur le site. Les modalités de paiement
+            sont précisées au moment de la réservation. Les paiements sont traités par un prestataire tiers sécurisé.
+          </p>
+
+          <h2>4. Politique d'annulation</h2>
+          <p>
+            Les conditions d'annulation et de report des séances sont précisées dans l'entente de service remise lors de
+            ton inscription. De façon générale, j'apprécie un préavis raisonnable (24 à 48 heures) pour toute annulation.
+          </p>
+
+          <h2>5. Responsabilité</h2>
+          <p>
+            L'entraînement physique comporte des risques inhérents. Avant de commencer, je te recommande fortement de
+            consulter un professionnel de la santé si tu as des conditions médicales particulières.
+          </p>
+          <p>
+            Je m'engage à offrir mes services avec compétence, soin et professionnalisme. Toutefois, les résultats varient
+            d'une personne à l'autre et dépendent de nombreux facteurs (assiduité, alimentation, génétique, santé
+            générale). Je ne garantis pas de résultats spécifiques.
+          </p>
+          <p>
+            Tu es responsable de m'informer de toute condition médicale, blessure ou limitation qui pourrait affecter ta
+            sécurité pendant les séances.
+          </p>
+
+          <h2>6. Propriété intellectuelle</h2>
+          <p>
+            Tout le contenu de ce site (textes, images, logo, programmes d'entraînement remis aux clientes) est ma
+            propriété et est protégé par les lois sur le droit d'auteur. Toute reproduction ou utilisation sans
+            autorisation est interdite.
+          </p>
+
+          <h2>7. Confidentialité</h2>
+          <p>
+            Ton utilisation du site est également régie par ma politique de confidentialité, disponible à l'adresse :
+            /politique-de-confidentialite
+          </p>
+
+          <h2>8. Modifications</h2>
+          <p>
+            Je me réserve le droit de modifier ces conditions à tout moment. La date de la dernière mise à jour figure en
+            haut du document. Les conditions en vigueur au moment de la réservation de services s'appliquent à cette
+            réservation.
+          </p>
+
+          <h2>9. Droit applicable</h2>
+          <p>
+            Les présentes conditions sont régies par les lois du Québec et du Canada. Tout litige sera soumis à la
+            compétence exclusive des tribunaux du district judiciaire de Montréal.
+          </p>
+
+          <h2>10. Nous contacter</h2>
+          <p>Pour toute question concernant ces conditions, tu peux me contacter à :</p>
+          <p><a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a></p>
+
+          <p class="legal-note">
+            <em
+              >Ce document est un modèle générique. Pour des conditions adaptées à ta situation juridique particulière,
+              consulte un conseiller juridique.</em
+            >
+          </p>
+
+          <!-- Note to dev: This placeholder content was generated as a starting template. The client should have a legal professional review before this goes live on production. -->
         </div>
       </section>
     </main>

--- a/conditions-utilisation/index.html
+++ b/conditions-utilisation/index.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Conditions d'utilisation — Éliane Larre, entraîneure personnelle privée à Montréal." />
+    <title>Conditions d'utilisation — Éliane Larre</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Poppins:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="legal-page">
+    <a class="skip-link" href="#contenu-principal">Passer au contenu</a>
+
+    <header class="site-nav" id="site-nav" data-nav>
+      <a class="nav-logo" href="/#accueil" aria-label="Éliane Larre — Accueil"><em>Éliane Larre</em></a>
+      <nav aria-label="Navigation principale">
+        <ul class="nav-desktop">
+          <li><a href="/#introduction">Introduction</a></li>
+          <li class="nav-dropdown" data-nav-dropdown>
+            <button
+              type="button"
+              class="nav-dropdown-trigger"
+              id="nav-offres-trigger"
+              data-nav-dropdown-trigger
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-controls="nav-offres-menu"
+            >
+              <span class="nav-dropdown-trigger__label">Offres</span>
+              <svg
+                class="nav-dropdown-chevron"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M6 9l6 6 6-6"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <div
+              class="nav-dropdown-panel"
+              id="nav-offres-menu"
+              data-nav-dropdown-panel
+              role="menu"
+              aria-labelledby="nav-offres-trigger"
+              hidden
+            >
+              <div class="nav-dropdown-panel__surface">
+                <a href="/offres/offre-1" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 1</a>
+                <a href="/offres/offre-2" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 2</a>
+              </div>
+            </div>
+          </li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+      </nav>
+      <a
+        class="nav-cta nav-cta--outline"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Appel découverte</a>
+      <button
+        type="button"
+        class="nav-toggle"
+        aria-expanded="false"
+        aria-controls="nav-mobile"
+        data-nav-toggle
+        aria-label="Ouvrir le menu"
+      >
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+    </header>
+
+    <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
+      <ul>
+        <li><a href="/#introduction" data-nav-link>Introduction</a></li>
+        <li><a href="/#programme" data-nav-link>Programme</a></li>
+        <li><a href="/#faq" data-nav-link>FAQ</a></li>
+      </ul>
+      <a
+        class="btn btn-primary nav-mobile-cta"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-nav-link
+        >Appel découverte</a
+      >
+    </div>
+
+    <main id="contenu-principal" class="legal-main">
+      <section class="legal-section">
+        <div class="legal-inner">
+          <h1>Conditions d'utilisation</h1>
+          <p class="legal-updated"><em>Dernière mise à jour : avril 2026</em></p>
+          <p>Cette page sera bientôt complétée avec les conditions d'utilisation officielles d'Éliane Larre.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
+          <p class="footer-brand"><em>Éliane Larre</em></p>
+          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-location">Montréal, Québec</p>
+        </section>
+
+        <nav class="footer-col footer-col--nav" aria-label="Navigation pied de page">
+          <h3 class="footer-title">Navigation</h3>
+          <ul class="footer-links">
+            <li><a href="/#introduction">Introduction</a></li>
+            <li>
+              <a href="/#programme">Offres</a>
+              <ul class="footer-sublinks">
+                <li><a href="/offres/offre-1">Offre 1</a></li>
+                <li><a href="/offres/offre-2">Offre 2</a></li>
+              </ul>
+            </li>
+            <li><a href="/#faq">FAQ</a></li>
+            <li>
+              <a href="https://cal.com/elianelarre/appel-decouverte" target="_blank" rel="noopener noreferrer"
+                >Appel découverte</a
+              >
+            </li>
+          </ul>
+        </nav>
+
+        <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
+          <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
+          <address class="footer-contact-list">
+            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a
+              class="footer-ig-link"
+              href="https://www.instagram.com/eliane.au.naturel"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram @elianelarre (nouvel onglet)"
+            >
+              <svg class="footer-ig-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path
+                  d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zm0 10.162a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 11-2.881 0 1.44 1.44 0 012.881 0z"
+                />
+              </svg>
+            </a>
+          </address>
+        </section>
+
+        <nav class="footer-col footer-col--legal" aria-label="Liens légaux">
+          <h3 class="footer-title">Légal</h3>
+          <ul class="footer-links">
+            <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
+            <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+          </ul>
+        </nav>
+      </div>
+      <div class="footer-bottom">
+        <p class="footer-bottom-copy">© 2026 Éliane Larre. Tous droits réservés.</p>
+        <p class="footer-bottom-credit">
+          <a href="https://wfwonder.com/" target="_blank" rel="noopener noreferrer">WorkflowWonder ✦</a>
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -630,6 +630,11 @@
                 <span class="eyebrow">Les avantages des poids libres et accessoires</span>
                 <h2>Pourquoi j'utilise les <em>poids libres et accessoires</em></h2>
               </div>
+              <div class="poids-libres-divider" aria-hidden="true">
+                <span class="poids-libres-divider__line"></span>
+                <span class="poids-libres-divider__dot"></span>
+                <span class="poids-libres-divider__line"></span>
+              </div>
               <ul class="imagine-list poids-libres-list">
                 <li class="reveal" data-reveal>
                   <strong>accessibles</strong> dans tous les gyms comme à la maison

--- a/index.html
+++ b/index.html
@@ -652,6 +652,15 @@
                   <strong>offrent</strong> beaucoup de variété dans la progression
                 </li>
               </ul>
+              <div class="poids-libres-cta-wrap reveal" data-reveal>
+                <a
+                  class="btn btn-primary"
+                  href="https://cal.com/elianelarre/appel-decouverte"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >TROUVE LA BONNE APPROCHE</a
+                >
+              </div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -630,11 +630,6 @@
                 <span class="eyebrow">Les avantages des poids libres et accessoires</span>
                 <h2>Pourquoi j'utilise les <em>poids libres et accessoires</em></h2>
               </div>
-              <div class="poids-libres-divider" aria-hidden="true">
-                <span class="poids-libres-divider__line"></span>
-                <span class="poids-libres-divider__dot"></span>
-                <span class="poids-libres-divider__line"></span>
-              </div>
               <ul class="imagine-list poids-libres-list">
                 <li class="reveal" data-reveal>
                   <strong>accessibles</strong> dans tous les gyms comme à la maison

--- a/index.html
+++ b/index.html
@@ -815,7 +815,7 @@
               rel="noopener noreferrer"
               >Appel découverte</a
             >
-            <span class="cta-note">Sans engagement · Places limitées</span>
+            <span class="cta-note">Sans engagement</span>
           </div>
         </div>
       </div>
@@ -911,12 +911,11 @@
         <div class="close-inner">
           <div class="accent-bar" aria-hidden="true"></div>
           <h2 class="reveal" data-reveal>
-            Dans 12 semaines, tu regarderas en arrière.<br />
-            <em>Et tu sauras que c'est ici que tout a changé.</em>
+            Après notre travail ensemble, tu auras des outils concrets <em>pour continuer à avancer.</em>
           </h2>
           <p class="reveal" data-reveal>
-            Réserve ton appel découverte gratuit. On fait connaissance, on clarifie tes objectifs et tu repars avec une
-            idée claire de la prochaine étape. Sans engagement.
+            Réserve un appel découverte gratuit pour qu'on puisse voir où tu en es et comment je peux t'aider. Sans
+            engagement.
           </p>
           <div class="close-actions reveal" data-reveal>
             <a
@@ -926,29 +925,73 @@
               rel="noopener noreferrer"
               >Appel découverte</a
             >
-            <span class="close-note">Places limitées · Aucun engagement</span>
+            <span class="close-note">Aucun engagement</span>
           </div>
         </div>
       </section>
     </main>
 
     <footer class="site-footer">
-      <div class="footer-brand"><em>Éliane</em></div>
-      <p class="footer-mid">Entraîneure personnelle privée · Montréal</p>
-      <div class="footer-ig">
-        <a
-          class="footer-ig-link"
-          href="https://www.instagram.com/eliane.au.naturel"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Instagram — profil @eliane.au.naturel (nouvel onglet)"
-        >
-          <svg class="footer-ig-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path
-              d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zm0 10.162a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 11-2.881 0 1.44 1.44 0 012.881 0z"
-            />
-          </svg>
-        </a>
+      <div class="footer-inner">
+        <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
+          <p class="footer-brand"><em>Éliane Larre</em></p>
+          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-location">Montréal, Québec</p>
+        </section>
+
+        <nav class="footer-col footer-col--nav" aria-label="Navigation pied de page">
+          <h3 class="footer-title">Navigation</h3>
+          <ul class="footer-links">
+            <li><a href="#introduction">Introduction</a></li>
+            <li>
+              <a href="#programme">Offres</a>
+              <ul class="footer-sublinks">
+                <li><a href="/offres/offre-1">Offre 1</a></li>
+                <li><a href="/offres/offre-2">Offre 2</a></li>
+              </ul>
+            </li>
+            <li><a href="#faq">FAQ</a></li>
+            <li>
+              <a href="https://cal.com/elianelarre/appel-decouverte" target="_blank" rel="noopener noreferrer"
+                >Appel découverte</a
+              >
+            </li>
+          </ul>
+        </nav>
+
+        <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
+          <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
+          <address class="footer-contact-list">
+            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a
+              class="footer-ig-link"
+              href="https://www.instagram.com/eliane.au.naturel"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram @elianelarre (nouvel onglet)"
+            >
+              <svg class="footer-ig-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path
+                  d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zm0 10.162a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 11-2.881 0 1.44 1.44 0 012.881 0z"
+                />
+              </svg>
+            </a>
+          </address>
+        </section>
+
+        <nav class="footer-col footer-col--legal" aria-label="Liens légaux">
+          <h3 class="footer-title">Légal</h3>
+          <ul class="footer-links">
+            <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
+            <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+          </ul>
+        </nav>
+      </div>
+      <div class="footer-bottom">
+        <p class="footer-bottom-copy">© 2026 Éliane Larre. Tous droits réservés.</p>
+        <p class="footer-bottom-credit">
+          <a href="https://wfwonder.com/" target="_blank" rel="noopener noreferrer">WorkflowWonder ✦</a>
+        </p>
       </div>
     </footer>
   </body>

--- a/politique-de-confidentialite/index.html
+++ b/politique-de-confidentialite/index.html
@@ -1,0 +1,278 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Politique de confidentialité — Éliane Larre, entraîneure personnelle privée à Montréal."
+    />
+    <title>Politique de confidentialité — Éliane Larre</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Poppins:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="legal-page">
+    <a class="skip-link" href="#contenu-principal">Passer au contenu</a>
+
+    <header class="site-nav" id="site-nav" data-nav>
+      <a class="nav-logo" href="/#accueil" aria-label="Éliane Larre — Accueil"><em>Éliane Larre</em></a>
+      <nav aria-label="Navigation principale">
+        <ul class="nav-desktop">
+          <li><a href="/#introduction">Introduction</a></li>
+          <li class="nav-dropdown" data-nav-dropdown>
+            <button
+              type="button"
+              class="nav-dropdown-trigger"
+              id="nav-offres-trigger"
+              data-nav-dropdown-trigger
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-controls="nav-offres-menu"
+            >
+              <span class="nav-dropdown-trigger__label">Offres</span>
+              <svg
+                class="nav-dropdown-chevron"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M6 9l6 6 6-6"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <div
+              class="nav-dropdown-panel"
+              id="nav-offres-menu"
+              data-nav-dropdown-panel
+              role="menu"
+              aria-labelledby="nav-offres-trigger"
+              hidden
+            >
+              <div class="nav-dropdown-panel__surface">
+                <a href="/offres/offre-1" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 1</a>
+                <a href="/offres/offre-2" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 2</a>
+              </div>
+            </div>
+          </li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+      </nav>
+      <a
+        class="nav-cta nav-cta--outline"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Appel découverte</a>
+      <button
+        type="button"
+        class="nav-toggle"
+        aria-expanded="false"
+        aria-controls="nav-mobile"
+        data-nav-toggle
+        aria-label="Ouvrir le menu"
+      >
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+    </header>
+
+    <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
+      <ul>
+        <li><a href="/#introduction" data-nav-link>Introduction</a></li>
+        <li><a href="/#programme" data-nav-link>Programme</a></li>
+        <li><a href="/#faq" data-nav-link>FAQ</a></li>
+      </ul>
+      <a
+        class="btn btn-primary nav-mobile-cta"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        target="_blank"
+        rel="noopener noreferrer"
+        data-nav-link
+        >Appel découverte</a
+      >
+    </div>
+
+    <main id="contenu-principal" class="legal-main">
+      <section class="legal-section">
+        <div class="legal-inner">
+          <h1>Politique de confidentialité</h1>
+          <p class="legal-updated"><em>Dernière mise à jour : avril 2026</em></p>
+
+          <p>
+            La présente politique de confidentialité décrit la manière dont Éliane Larre ("je", "mon", "mes") recueille,
+            utilise et protège les renseignements personnels que tu me fournis lorsque tu visites ce site web ou que tu
+            utilises mes services d'entraînement personnel.
+          </p>
+
+          <h2>1. Renseignements recueillis</h2>
+          <p>Je peux recueillir les renseignements suivants :</p>
+          <ul>
+            <li>Nom et prénom</li>
+            <li>Adresse courriel</li>
+            <li>Numéro de téléphone (si tu choisis de me le fournir)</li>
+            <li>
+              Informations liées à ta santé, à ton historique d'entraînement et à tes objectifs, lorsque tu me les
+              transmets volontairement dans le cadre d'un accompagnement
+            </li>
+            <li>
+              Informations de paiement (traitées via un prestataire sécurisé; je ne conserve pas tes données de carte)
+            </li>
+            <li>
+              Données techniques anonymisées (type de navigateur, pages consultées) via des outils d'analyse standard
+            </li>
+          </ul>
+
+          <h2>2. Utilisation des renseignements</h2>
+          <p>Les renseignements recueillis sont utilisés pour :</p>
+          <ul>
+            <li>Répondre à tes demandes de renseignements</li>
+            <li>Planifier et offrir les séances d'entraînement</li>
+            <li>Adapter les programmes à tes objectifs</li>
+            <li>Gérer la facturation et les paiements</li>
+            <li>T'envoyer des communications liées à nos échanges ou aux services offerts</li>
+          </ul>
+          <p>
+            Tes renseignements ne sont jamais vendus, loués ou partagés à des fins commerciales avec des tiers.
+          </p>
+
+          <h2>3. Partage avec des tiers</h2>
+          <p>
+            Je peux partager certains renseignements avec des prestataires de services tiers uniquement lorsque nécessaire
+            à l'exécution des services (exemples : outil de prise de rendez-vous, processeur de paiement, plateforme
+            d'envoi de courriels). Ces prestataires sont tenus de respecter la confidentialité de tes données.
+          </p>
+
+          <h2>4. Conservation des données</h2>
+          <p>
+            Tes renseignements personnels sont conservés uniquement pour la durée nécessaire à la prestation des services
+            et au respect de mes obligations légales, fiscales et comptables.
+          </p>
+
+          <h2>5. Tes droits</h2>
+          <p>
+            Conformément à la Loi sur la protection des renseignements personnels dans le secteur privé (Québec) et à la
+            Loi 25, tu as le droit :
+          </p>
+          <ul>
+            <li>D'accéder aux renseignements personnels que je détiens à ton sujet</li>
+            <li>De demander la rectification de renseignements inexacts</li>
+            <li>De demander la suppression de tes renseignements (sous réserve des obligations légales)</li>
+            <li>De retirer ton consentement au traitement de tes données</li>
+            <li>De porter plainte auprès de la Commission d'accès à l'information du Québec</li>
+          </ul>
+          <p>Pour exercer ces droits, communique avec moi à l'adresse : contact@eliane-larre.com</p>
+
+          <h2>6. Témoins (cookies)</h2>
+          <p>
+            Ce site peut utiliser des témoins (cookies) pour améliorer ton expérience de navigation et recueillir des
+            données d'utilisation anonymisées. Tu peux configurer ton navigateur pour refuser les témoins, mais certaines
+            fonctionnalités du site pourraient alors être limitées.
+          </p>
+
+          <h2>7. Sécurité</h2>
+          <p>
+            Je prends des mesures raisonnables pour protéger tes renseignements personnels contre l'accès non autorisé, la
+            perte ou la divulgation. Toutefois, aucun système n'est totalement sécurisé, et je ne peux garantir une
+            sécurité absolue.
+          </p>
+
+          <h2>8. Modifications de la politique</h2>
+          <p>
+            Cette politique peut être modifiée à tout moment. La date de la dernière mise à jour figure en haut du
+            document. Je t'invite à la consulter régulièrement.
+          </p>
+
+          <h2>9. Nous contacter</h2>
+          <p>Pour toute question concernant cette politique de confidentialité, tu peux me contacter à :</p>
+          <p><a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a></p>
+
+          <p class="legal-note">
+            <em
+              >Ce document est un modèle générique. Pour une politique adaptée à ta situation juridique particulière,
+              consulte un conseiller juridique.</em
+            >
+          </p>
+
+          <!-- Note to dev: This placeholder content was generated as a starting template. The client should have a legal professional review before this goes live on production. -->
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
+          <p class="footer-brand"><em>Éliane Larre</em></p>
+          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-location">Montréal, Québec</p>
+        </section>
+
+        <nav class="footer-col footer-col--nav" aria-label="Navigation pied de page">
+          <h3 class="footer-title">Navigation</h3>
+          <ul class="footer-links">
+            <li><a href="/#introduction">Introduction</a></li>
+            <li>
+              <a href="/#programme">Offres</a>
+              <ul class="footer-sublinks">
+                <li><a href="/offres/offre-1">Offre 1</a></li>
+                <li><a href="/offres/offre-2">Offre 2</a></li>
+              </ul>
+            </li>
+            <li><a href="/#faq">FAQ</a></li>
+            <li>
+              <a href="https://cal.com/elianelarre/appel-decouverte" target="_blank" rel="noopener noreferrer"
+                >Appel découverte</a
+              >
+            </li>
+          </ul>
+        </nav>
+
+        <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
+          <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
+          <address class="footer-contact-list">
+            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a
+              class="footer-ig-link"
+              href="https://www.instagram.com/eliane.au.naturel"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram @elianelarre (nouvel onglet)"
+            >
+              <svg class="footer-ig-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path
+                  d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zm0 10.162a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 11-2.881 0 1.44 1.44 0 012.881 0z"
+                />
+              </svg>
+            </a>
+          </address>
+        </section>
+
+        <nav class="footer-col footer-col--legal" aria-label="Liens légaux">
+          <h3 class="footer-title">Légal</h3>
+          <ul class="footer-links">
+            <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
+            <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+          </ul>
+        </nav>
+      </div>
+      <div class="footer-bottom">
+        <p class="footer-bottom-copy">© 2026 Éliane Larre. Tous droits réservés.</p>
+        <p class="footer-bottom-credit">
+          <a href="https://wfwonder.com/" target="_blank" rel="noopener noreferrer">WorkflowWonder ✦</a>
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/style.css
+++ b/src/style.css
@@ -2056,19 +2056,20 @@ button:focus-visible {
 }
 
 .poids-libres-list {
-  margin-top: 2.25rem;
+  margin-top: 2rem;
   max-width: 42rem;
 }
 
 .poids-libres-layout {
   display: grid;
-  grid-template-columns: minmax(0, 0.44fr) minmax(0, 0.56fr);
+  grid-template-columns: minmax(0, 0.38fr) minmax(0, 0.62fr);
   gap: clamp(3rem, 5vw, 4rem);
   align-items: start;
 }
 
 .poids-libres-media {
   min-width: 0;
+  margin-top: clamp(3.75rem, 6vw, 5rem);
 }
 
 .poids-libres-media-frame {
@@ -2093,8 +2094,12 @@ button:focus-visible {
 
 @media (min-width: 768px) and (max-width: 1023px) {
   .poids-libres-layout {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 0.42fr) minmax(0, 0.58fr);
     gap: clamp(2rem, 4vw, 2.5rem);
+  }
+
+  .poids-libres-media {
+    margin-top: clamp(1.875rem, 4vw, 2.5rem);
   }
 }
 
@@ -2108,8 +2113,39 @@ button:focus-visible {
     max-height: 400px;
   }
 
+  .poids-libres-media {
+    margin-top: 0;
+  }
+
   .poids-libres-list {
-    margin-top: 2rem;
+    margin-top: 1.5rem;
+  }
+}
+
+.poids-libres-divider {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 1.75rem 0 1.75rem;
+  color: rgba(90, 80, 72, 0.38);
+}
+
+.poids-libres-divider__line {
+  width: 3.5rem;
+  height: 1px;
+  background: currentColor;
+}
+
+.poids-libres-divider__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--plum);
+}
+
+@media (max-width: 767px) {
+  .poids-libres-divider {
+    margin: 1.5rem 0 1.25rem;
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -2069,10 +2069,10 @@ button:focus-visible {
 
 .poids-libres-media {
   min-width: 0;
-  margin-top: clamp(3.75rem, 6vw, 5rem);
 }
 
 .poids-libres-media-frame {
+  margin-top: clamp(3.75rem, 6vw, 5rem);
   border-radius: clamp(16px, 2vw, 24px);
   overflow: hidden;
   background: var(--beige-deep);
@@ -2092,13 +2092,20 @@ button:focus-visible {
   min-width: 0;
 }
 
+.poids-libres-content h2 {
+  max-width: 22ch;
+  margin-bottom: 0;
+  font-size: clamp(1.8rem, 3.2vw, 2.95rem);
+  text-wrap: balance;
+}
+
 @media (min-width: 768px) and (max-width: 1023px) {
   .poids-libres-layout {
     grid-template-columns: minmax(0, 0.42fr) minmax(0, 0.58fr);
     gap: clamp(2rem, 4vw, 2.5rem);
   }
 
-  .poids-libres-media {
+  .poids-libres-media-frame {
     margin-top: clamp(1.875rem, 4vw, 2.5rem);
   }
 }
@@ -2113,7 +2120,7 @@ button:focus-visible {
     max-height: 400px;
   }
 
-  .poids-libres-media {
+  .poids-libres-media-frame {
     margin-top: 0;
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -2072,7 +2072,8 @@ button:focus-visible {
 }
 
 .poids-libres-media-frame {
-  margin-top: clamp(3.75rem, 6vw, 5rem);
+  margin-top: 0;
+  transform: translateY(clamp(3.75rem, 6vw, 5rem));
   border-radius: clamp(16px, 2vw, 24px);
   overflow: hidden;
   background: var(--beige-deep);
@@ -2106,7 +2107,7 @@ button:focus-visible {
   }
 
   .poids-libres-media-frame {
-    margin-top: clamp(1.875rem, 4vw, 2.5rem);
+    transform: translateY(clamp(1.875rem, 4vw, 2.5rem));
   }
 }
 
@@ -2121,7 +2122,7 @@ button:focus-visible {
   }
 
   .poids-libres-media-frame {
-    margin-top: 0;
+    transform: none;
   }
 
   .poids-libres-list {

--- a/src/style.css
+++ b/src/style.css
@@ -897,6 +897,66 @@ button:focus-visible {
   margin: 0 auto;
 }
 
+/* —— Legal page —— */
+.legal-main {
+  padding-top: calc(var(--nav-h) + clamp(2.5rem, 5vw, 4rem));
+}
+
+.legal-section {
+  padding: 0 var(--pad-x) clamp(4rem, 8vw, 6rem);
+}
+
+.legal-inner {
+  max-width: 47.5rem;
+  margin: 0 auto;
+}
+
+.legal-inner h1 {
+  font-family: var(--font-serif);
+  font-size: clamp(2rem, 3.2vw, 3rem);
+  font-weight: 400;
+  line-height: 1.14;
+  color: var(--ink);
+  margin: 0 0 0.75rem;
+}
+
+.legal-updated {
+  margin: 0 0 2rem;
+  color: var(--muted);
+  font-size: 0.9375rem;
+}
+
+.legal-inner h2 {
+  font-family: var(--font-serif);
+  font-size: clamp(1.4rem, 2.2vw, 1.8rem);
+  font-weight: 400;
+  line-height: 1.22;
+  color: var(--ink);
+  margin: 2.25rem 0 0.9rem;
+}
+
+.legal-inner p,
+.legal-inner li {
+  font-size: 1rem;
+  line-height: 1.78;
+  color: var(--mid);
+}
+
+.legal-inner p {
+  margin: 0 0 1rem;
+}
+
+.legal-inner ul {
+  margin: 0 0 1.25rem 1.3rem;
+  padding: 0;
+}
+
+.legal-note {
+  margin-top: 2.25rem;
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
 .eyebrow {
   display: block;
   font-size: 0.6875rem;
@@ -2350,7 +2410,7 @@ button:focus-visible {
 .cta-band-actions {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.65rem;
 }
 
@@ -2494,20 +2554,38 @@ button:focus-visible {
 /* —— Footer —— */
 .site-footer {
   background: var(--ink);
-  color: rgba(255, 255, 255, 0.35);
-  padding: 2.75rem var(--pad-x);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.25rem;
+  color: rgba(255, 255, 255, 0.7);
+  padding: clamp(4rem, 8vw, 5rem) var(--pad-x) clamp(2.5rem, 4vw, 3rem);
+}
+
+.footer-inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: clamp(2rem, 4vw, 3.5rem);
+  align-items: start;
+}
+
+.footer-col {
+  min-width: 0;
+}
+
+.footer-title {
+  margin: 0 0 0.9rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--gold);
 }
 
 .footer-brand {
+  margin: 0 0 0.85rem;
   font-family: var(--font-serif);
-  font-size: 1rem;
+  font-size: 1.0625rem;
   font-weight: 400;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -2516,16 +2594,75 @@ button:focus-visible {
   color: var(--gold);
 }
 
-.footer-mid {
-  font-size: 0.6875rem;
-  letter-spacing: 0.06em;
+.footer-tagline,
+.footer-location {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.footer-location {
+  margin-top: 0.3rem;
+}
+
+.footer-links,
+.footer-sublinks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.footer-sublinks {
+  margin-top: 0.45rem;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.footer-links a {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+  color: var(--gold);
+}
+
+.footer-contact-list {
+  margin: 0;
+  font-style: normal;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.footer-contact-list > a {
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  transition: color 0.2s ease;
+}
+
+.footer-contact-list > a:hover {
+  color: var(--gold);
 }
 
 .footer-ig-link {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  color: rgba(255, 255, 255, 0.45);
+  justify-content: flex-start;
+  gap: 0.55rem;
+  color: rgba(255, 255, 255, 0.75);
   transition:
     color 0.2s,
     transform 0.2s;
@@ -2533,18 +2670,66 @@ button:focus-visible {
 
 .footer-ig-link:hover {
   color: var(--gold);
-  transform: scale(1.06);
+  transform: translateY(-1px);
 }
 
 .footer-ig-icon {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
-@media (max-width: 700px) {
-  .site-footer {
+.footer-bottom {
+  max-width: var(--max);
+  margin: clamp(2rem, 4vw, 2.5rem) auto 0;
+  padding-top: 1.15rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-bottom-copy,
+.footer-bottom-credit {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.footer-bottom-credit {
+  text-align: right;
+}
+
+.footer-bottom-credit a {
+  color: rgba(255, 255, 255, 0.75);
+  transition: color 0.2s ease;
+}
+
+.footer-bottom-credit a:hover {
+  color: var(--gold);
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .footer-inner {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2rem 2.5rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .footer-inner {
+    grid-template-columns: 1fr;
+    gap: 1.75rem;
+  }
+
+  .footer-bottom {
     flex-direction: column;
-    text-align: center;
+    align-items: flex-start;
+  }
+
+  .footer-bottom-credit {
+    text-align: left;
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -2056,7 +2056,7 @@ button:focus-visible {
 }
 
 .poids-libres-list {
-  margin-top: 2rem;
+  margin-top: clamp(2rem, 3vw, 3rem);
   max-width: 42rem;
 }
 
@@ -2130,37 +2130,10 @@ button:focus-visible {
   }
 }
 
-.poids-libres-divider {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6rem;
-  margin: 1.75rem 0 1.75rem;
-  color: rgba(90, 80, 72, 0.38);
-}
-
 .poids-libres-cta-wrap {
   display: flex;
   justify-content: center;
   margin-top: clamp(3rem, 5vw, 4rem);
-}
-
-.poids-libres-divider__line {
-  width: 3.5rem;
-  height: 1px;
-  background: currentColor;
-}
-
-.poids-libres-divider__dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--plum);
-}
-
-@media (max-width: 767px) {
-  .poids-libres-divider {
-    margin: 1.5rem 0 1.25rem;
-  }
 }
 
 /* —— Programme —— */

--- a/src/style.css
+++ b/src/style.css
@@ -2138,6 +2138,12 @@ button:focus-visible {
   color: rgba(90, 80, 72, 0.38);
 }
 
+.poids-libres-cta-wrap {
+  display: flex;
+  justify-content: center;
+  margin-top: clamp(3rem, 5vw, 4rem);
+}
+
 .poids-libres-divider__line {
   width: 3.5rem;
   height: 1px;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,37 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 
+const LEGAL_ROUTES = ['/politique-de-confidentialite', '/conditions-utilisation'];
+
+function cleanRouteRedirectPlugin() {
+  const redirect = (middlewares) => {
+    middlewares.use((req, res, next) => {
+      if (!req.url) return next();
+      const path = req.url.split('?')[0];
+      if (LEGAL_ROUTES.includes(path)) {
+        res.statusCode = 302;
+        res.setHeader('Location', `${path}/`);
+        res.end();
+        return;
+      }
+      next();
+    });
+  };
+
+  return {
+    name: 'legal-clean-route-redirect',
+    configureServer(server) {
+      redirect(server.middlewares);
+    },
+    configurePreviewServer(server) {
+      redirect(server.middlewares);
+    },
+  };
+}
+
 export default defineConfig({
+  appType: 'mpa',
+  plugins: [cleanRouteRedirectPlugin()],
   root: '.',
   publicDir: 'public',
   build: {
@@ -12,6 +42,7 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         politiqueDeConfidentialite: resolve(__dirname, 'politique-de-confidentialite/index.html'),
+        conditionsUtilisation: resolve(__dirname, 'conditions-utilisation/index.html'),
       },
       output: {
         manualChunks: undefined,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
 
 export default defineConfig({
   root: '.',
@@ -8,6 +9,10 @@ export default defineConfig({
     assetsDir: 'assets',
     sourcemap: false,
     rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        politiqueDeConfidentialite: resolve(__dirname, 'politique-de-confidentialite/index.html'),
+      },
       output: {
         manualChunks: undefined,
       },


### PR DESCRIPTION
Closes #26
Fixes #28
Fixes #29
Fixes #30
Fixes #31
Fixes #32
Fixes #33

## Summary
- refine #poids-libres editorial layout (text ratio, heading wrap, visible image offset, and CTA placement)
- remove the decorative divider and keep a direct title-to-list rhythm
- expand footer into a responsive 4-column structure with legal/navigation/contact details and bottom bar polish
- add /politique-de-confidentialite as a dedicated legal page with shared nav/footer and readable legal typography
- fix legal clean URL handling in dev/preview so /politique-de-confidentialite and /conditions-utilisation resolve cleanly
- add /conditions-utilisation route and populate it with full French legal content

## How I verified
- 
pm run build
- confirmed multi-page build output includes:
  - dist/politique-de-confidentialite/index.html
  - dist/conditions-utilisation/index.html
- direct dev checks confirm legal routes resolve and homepage footer links to both legal pages

## Notes
- no hardcoded localhost or production base URLs were introduced in app code
- legal pages share nav/footer and the same readable legal template styles
