### PR TITLE
Implement cookie consent flow and consent-gated analytics (Closes #34)

### DIFF
--- a/conditions-utilisation/index.html
+++ b/conditions-utilisation/index.html
@@ -248,6 +248,7 @@
           <ul class="footer-links">
             <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
             <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+            <li><a href="#" data-cookie-preferences-link>Gérer mes préférences de témoins</a></li>
           </ul>
         </nav>
       </div>

--- a/index.html
+++ b/index.html
@@ -984,6 +984,7 @@
           <ul class="footer-links">
             <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
             <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+            <li><a href="#" data-cookie-preferences-link>Gérer mes préférences de témoins</a></li>
           </ul>
         </nav>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "eliane-site",
       "version": "1.0.0",
       "dependencies": {
-        "lucide": "^1.8.0"
+        "@vercel/analytics": "^2.0.1",
+        "lucide": "^1.8.0",
+        "vanilla-cookieconsent": "^3.1.0"
       },
       "devDependencies": {
         "sharp": "^0.34.5",
@@ -1315,6 +1317,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1611,6 +1655,12 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/vanilla-cookieconsent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz",
+      "integrity": "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "vite": "^6.2.0"
   },
   "dependencies": {
-    "lucide": "^1.8.0"
+    "@vercel/analytics": "^2.0.1",
+    "lucide": "^1.8.0",
+    "vanilla-cookieconsent": "^3.1.0"
   }
 }

--- a/politique-de-confidentialite/index.html
+++ b/politique-de-confidentialite/index.html
@@ -177,9 +177,24 @@
 
           <h2>6. Témoins (cookies)</h2>
           <p>
-            Ce site peut utiliser des témoins (cookies) pour améliorer ton expérience de navigation et recueillir des
-            données d'utilisation anonymisées. Tu peux configurer ton navigateur pour refuser les témoins, mais certaines
-            fonctionnalités du site pourraient alors être limitées.
+            Ce site utilise des témoins (cookies) pour assurer son bon fonctionnement et, avec ton consentement, pour
+            mesurer le trafic du site. Les catégories de témoins sont les suivantes :
+          </p>
+          <ul>
+            <li><strong>Témoins nécessaires</strong> : essentiels au fonctionnement du site. Ils ne peuvent pas être désactivés.</li>
+            <li>
+              <strong>Témoins d'analyse</strong> : nous aident à comprendre comment les visiteurs utilisent le site. Ces
+              données sont anonymisées. Activés uniquement avec ton consentement.
+            </li>
+            <li>
+              <strong>Témoins de marketing</strong> : utilisés pour personnaliser les publicités. Actuellement aucun témoin
+              de marketing n'est actif sur ce site. Si cela change, ces témoins seront activés uniquement avec ton
+              consentement.
+            </li>
+          </ul>
+          <p>
+            Tu peux modifier tes préférences à tout moment en cliquant sur « Gérer mes préférences de témoins » au bas du
+            site.
           </p>
 
           <h2>7. Sécurité</h2>
@@ -264,6 +279,7 @@
           <ul class="footer-links">
             <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
             <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+            <li><a href="#" data-cookie-preferences-link>Gérer mes préférences de témoins</a></li>
           </ul>
         </nav>
       </div>

--- a/src/cookie-consent.css
+++ b/src/cookie-consent.css
@@ -1,0 +1,193 @@
+#cc-main {
+  --cc-bg: var(--beige);
+  --cc-primary-color: var(--ink);
+  --cc-btn-primary-bg: var(--plum);
+  --cc-btn-primary-color: var(--white);
+  --cc-btn-primary-border-color: var(--plum);
+  --cc-btn-primary-hover-bg: var(--plum-hover);
+  --cc-btn-primary-hover-border-color: var(--plum-hover);
+  --cc-btn-primary-hover-color: var(--white);
+  --cc-btn-secondary-bg: transparent;
+  --cc-btn-secondary-color: var(--plum);
+  --cc-btn-secondary-border-color: var(--plum);
+  --cc-btn-secondary-hover-bg: rgba(85, 39, 114, 0.1);
+  --cc-btn-secondary-hover-border-color: var(--plum-hover);
+  --cc-btn-secondary-hover-color: var(--plum-hover);
+  --cc-toggle-on-bg: var(--plum);
+  --cc-toggle-off-bg: #a9a3a0;
+  --cc-toggle-on-knob-bg: var(--white);
+  --cc-toggle-off-knob-bg: var(--white);
+  --cc-font-family: var(--font-sans);
+}
+
+#cc-main .cm,
+#cc-main .pm {
+  border-radius: 12px;
+  box-shadow: 0 16px 34px rgba(26, 20, 16, 0.2);
+  border: 1px solid rgba(90, 80, 72, 0.22);
+}
+
+#cc-main .cm {
+  max-width: 420px;
+  margin: 24px;
+  animation: cookie-consent-enter 260ms ease-out both;
+}
+
+#cc-main .pm {
+  animation: cookie-consent-enter 260ms ease-out both;
+}
+
+#cc-main .pm-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#cc-main .pm.pm--box {
+  display: flex !important;
+  flex-direction: column !important;
+  height: auto !important;
+  max-height: calc(100vh - 48px) !important;
+  top: 24px !important;
+  bottom: 24px !important;
+  transform: none !important;
+}
+
+#cc-main .pm__body {
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+  overflow-y: auto !important;
+  border-bottom: 1px solid rgba(90, 80, 72, 0.15);
+  box-shadow:
+    inset 0 -10px 12px -12px rgba(26, 20, 16, 0.24),
+    inset 0 10px 12px -12px rgba(26, 20, 16, 0.1);
+}
+
+#cc-main .cm__title,
+#cc-main .pm__title {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  color: var(--ink);
+}
+
+#cc-main .cm__desc,
+#cc-main .pm__section-desc {
+  color: var(--mid);
+}
+
+#cc-main .cm__btn,
+#cc-main .pm__btn {
+  min-height: 44px;
+  border-radius: 8px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+#cc-main .pm__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  background: var(--beige);
+  border-top: 1px solid rgba(90, 80, 72, 0.2);
+  flex-shrink: 0 !important;
+}
+
+#cc-main .cm__btn--secondary,
+#cc-main .pm__btn--secondary {
+  border-width: 1px;
+}
+
+#cc-main .cm__btn--close,
+#cc-main .pm__close-btn {
+  color: var(--mid);
+}
+
+#cc-main .cc-link,
+#cc-main .pm__section-title {
+  color: var(--plum);
+}
+
+#cc-main .pm__section--toggle .pm__section-title {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  font-weight: 400;
+}
+
+#cc-main .cm__footer a,
+#cc-main .pm__footer a {
+  color: var(--plum);
+}
+
+#cc-main .cm__btn[data-role='show'] {
+  border: none;
+  background: transparent;
+  color: var(--plum);
+  text-decoration: underline;
+  padding-inline: 0;
+  min-height: auto;
+}
+
+#cc-main .cm__btn[data-role='show']:hover {
+  color: var(--plum-hover);
+}
+
+#cc-main .cm-wrapper--hidden .cm,
+#cc-main .pm-wrapper--hidden .pm {
+  animation: cookie-consent-exit 220ms ease-in both;
+}
+
+@keyframes cookie-consent-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes cookie-consent-exit {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@media (max-width: 767px) {
+  #cc-main .cm {
+    max-width: none;
+    width: auto;
+    margin: 0 16px 16px;
+  }
+
+  #cc-main .cm__btns,
+  #cc-main .pm__btns {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+  }
+
+  #cc-main .cm__btn,
+  #cc-main .pm__btn {
+    width: 100%;
+  }
+
+  #cc-main .pm.pm--box {
+    max-height: calc(100vh - 16px) !important;
+    top: 8px !important;
+    bottom: 8px !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #cc-main .cm,
+  #cc-main .pm,
+  #cc-main .cm-wrapper--hidden .cm,
+  #cc-main .pm-wrapper--hidden .pm {
+    animation: none !important;
+  }
+}

--- a/src/cookie-consent.js
+++ b/src/cookie-consent.js
@@ -1,0 +1,135 @@
+import * as CookieConsent from 'vanilla-cookieconsent';
+import 'vanilla-cookieconsent/dist/cookieconsent.css';
+import './cookie-consent.css';
+
+const COOKIE_PREFERENCES_LINK_SELECTOR = '[data-cookie-preferences-link]';
+let analyticsInjected = false;
+
+function hasAnalyticsConsent(cookie) {
+  return Array.isArray(cookie?.categories) && cookie.categories.includes('analytics');
+}
+
+async function loadVercelAnalyticsIfConsented(cookie) {
+  if (analyticsInjected || !hasAnalyticsConsent(cookie)) return;
+  const { inject } = await import('@vercel/analytics');
+  inject();
+  analyticsInjected = true;
+}
+
+function onCookiePreferencesClick(event) {
+  event.preventDefault();
+  CookieConsent.showPreferences();
+}
+
+function bindCookiePreferencesLinks() {
+  const links = document.querySelectorAll(COOKIE_PREFERENCES_LINK_SELECTOR);
+  links.forEach((link) => {
+    link.addEventListener('click', onCookiePreferencesClick);
+  });
+}
+
+export function initCookieConsent() {
+  window.showCookiePreferences = () => CookieConsent.showPreferences();
+
+  CookieConsent.run({
+    cookie: {
+      useLocalStorage: true,
+      expiresAfterDays: 182,
+    },
+    guiOptions: {
+      consentModal: {
+        layout: 'box',
+        position: 'bottom left',
+        equalWeightButtons: true,
+      },
+      preferencesModal: {
+        layout: 'box',
+        equalWeightButtons: true,
+      },
+    },
+    categories: {
+      necessary: {
+        enabled: true,
+        readOnly: true,
+      },
+      analytics: {
+        enabled: false,
+        services: {
+          vercel_analytics: {
+            label: 'Vercel Analytics',
+            onAccept: () => {},
+            onReject: () => {},
+          },
+        },
+      },
+      marketing: {
+        enabled: false,
+        services: {
+          future_marketing_pixels: {
+            label: 'Pixels marketing (à venir)',
+          },
+        },
+      },
+    },
+    language: {
+      default: 'fr',
+      translations: {
+        fr: {
+          consentModal: {
+            title: 'On utilise des témoins 🍪',
+            description:
+              'Ce site utilise des témoins pour améliorer ton expérience et mesurer son trafic. Tu peux accepter, refuser ou personnaliser tes préférences. Tu peux changer ton choix à tout moment via le lien au bas du site.',
+            acceptAllBtn: 'Accepter tout',
+            acceptNecessaryBtn: 'Refuser tout',
+            showPreferencesBtn: 'Personnaliser',
+          },
+          preferencesModal: {
+            title: 'Préférences de témoins',
+            acceptAllBtn: 'Accepter tout',
+            acceptNecessaryBtn: 'Refuser tout',
+            savePreferencesBtn: 'Enregistrer mes choix',
+            sections: [
+              {
+                description:
+                  'Gère tes préférences par catégorie. Les témoins nécessaires ne peuvent pas être désactivés.',
+              },
+              {
+                title: 'Témoins nécessaires',
+                description:
+                  'Ces témoins sont nécessaires au bon fonctionnement du site et ne peuvent pas être désactivés.',
+                linkedCategory: 'necessary',
+              },
+              {
+                title: 'Témoins d\'analyse',
+                description:
+                  'Ces témoins nous permettent de mesurer le trafic du site et d\'améliorer ton expérience. Les données sont anonymisées.',
+                linkedCategory: 'analytics',
+              },
+              {
+                title: 'Témoins de marketing',
+                description:
+                  'Ces témoins sont utilisés pour personnaliser les publicités. Actuellement aucun témoin de marketing n\'est actif sur ce site.',
+                linkedCategory: 'marketing',
+              },
+              {
+                description:
+                  '<a href="/politique-de-confidentialite" class="cc-link">Politique de confidentialité</a>',
+              },
+            ],
+          },
+        },
+      },
+    },
+    // Vercel Analytics is gated by the "analytics" consent category.
+    // Add any future analytics tool (e.g., Google Analytics) with this same pattern.
+    // Marketing pixels should be wired under "marketing" and loaded only when that category is accepted.
+    onConsent: ({ cookie }) => {
+      void loadVercelAnalyticsIfConsented(cookie);
+    },
+    onChange: ({ cookie }) => {
+      void loadVercelAnalyticsIfConsented(cookie);
+    },
+  });
+
+  bindCookiePreferencesLinks();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import './style.css';
 import { initIntroPhotoDock } from './intro-photo-dock.js';
+import { initCookieConsent } from './cookie-consent.js';
 import { createIcons } from 'lucide';
 import Eye from 'lucide/dist/esm/icons/eye.js';
 import ShieldCheck from 'lucide/dist/esm/icons/shield-check.js';
@@ -313,3 +314,5 @@ initPresentielStaticMap();
 
 const faq = document.querySelector('[data-faq]');
 if (faq) initFaq(faq);
+
+initCookieConsent();


### PR DESCRIPTION
## Summary
- add vanilla-cookieconsent integration with French consent and preferences modals across homepage and legal pages
- implement compliant cookie category controls, footer preferences entry point, and policy section updates for cookie usage transparency
- gate Vercel Analytics behind explicit `analytics` consent using dynamic import callbacks on consent and preference changes

## Test plan
- [x] `npm run build`
- [x] Validate consent modal and preferences modal render with French content
- [x] Confirm privacy-policy footer link opens preferences modal
- [x] Confirm analytics loads only after enabling `analytics` consent category
- [x] Confirm analytics is not initialized when consent is refused/revoked on next page load

Made with [Cursor](https://cursor.com)