### PR TITLE
Add serverless Google Reviews endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ dist
 # Secrets / local env (never commit real keys)
 .env
 .env.local
+.env*.local
 .env.*.local
+.vercel

--- a/api/reviews.js
+++ b/api/reviews.js
@@ -1,0 +1,116 @@
+const GOOGLE_PLACES_BASE_URL = "https://places.googleapis.com/v1/places";
+const GOOGLE_FIELD_MASK =
+  "id,displayName,rating,userRatingCount,reviews,googleMapsUri";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function setCommonHeaders(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET");
+  res.setHeader(
+    "Cache-Control",
+    "public, s-maxage=21600, stale-while-revalidate=86400",
+  );
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+}
+
+function getReviewText(review) {
+  const originalText = review?.originalText?.text;
+  const originalTextLang = review?.originalText?.languageCode;
+  const reviewTextLang = review?.textLanguageCode;
+  const translatedText = review?.text?.text;
+
+  if (
+    originalText &&
+    ((!originalTextLang && !reviewTextLang) ||
+      (typeof originalTextLang === "string" && originalTextLang.startsWith("fr")) ||
+      (typeof reviewTextLang === "string" && reviewTextLang.startsWith("fr")))
+  ) {
+    return originalText;
+  }
+
+  return translatedText || originalText || "";
+}
+
+function sanitizeResponse(placePayload) {
+  const reviews = Array.isArray(placePayload?.reviews) ? placePayload.reviews : [];
+
+  return {
+    rating: placePayload?.rating ?? null,
+    reviewCount: placePayload?.userRatingCount ?? 0,
+    googleMapsUrl: placePayload?.googleMapsUri ?? null,
+    reviews: reviews.map((review) => ({
+      authorName: review?.authorAttribution?.displayName || "",
+      authorPhotoUrl: review?.authorAttribution?.photoUri || null,
+      rating: review?.rating ?? null,
+      text: getReviewText(review),
+      relativeTime: review?.relativePublishTimeDescription || "",
+      publishedAt: review?.publishTime || null,
+    })),
+  };
+}
+
+export default async function handler(req, res) {
+  setCommonHeaders(res);
+
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method Not Allowed. Use GET." });
+  }
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  const placeId = process.env.GOOGLE_PLACE_ID;
+
+  if (!apiKey || !placeId) {
+    return res.status(500).json({
+      error:
+        "Server configuration error: missing GOOGLE_PLACES_API_KEY or GOOGLE_PLACE_ID.",
+    });
+  }
+
+  const redactedKey = `${apiKey.slice(0, 6)}...`;
+  console.log("Google Places key prefix:", redactedKey);
+
+  const requestUrl = new URL(`${GOOGLE_PLACES_BASE_URL}/${encodeURIComponent(placeId)}`);
+  requestUrl.searchParams.set("languageCode", "fr");
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(requestUrl, {
+      method: "GET",
+      headers: {
+        "X-Goog-Api-Key": apiKey,
+        "X-Goog-FieldMask": GOOGLE_FIELD_MASK,
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("Google Places API error:", {
+        status: response.status,
+        statusText: response.statusText,
+        bodySnippet: errorText.slice(0, 500),
+      });
+      return res.status(502).json({ error: "Upstream Google Places API error." });
+    }
+
+    const placePayload = await response.json();
+    const transformed = sanitizeResponse(placePayload);
+
+    return res.status(200).json(transformed);
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      return res.status(504).json({ error: "Google Places request timed out." });
+    }
+
+    console.error("Unexpected reviews endpoint error:", {
+      message: error?.message,
+      keyPrefix: redactedKey,
+    });
+    return res.status(502).json({ error: "Failed to fetch Google reviews." });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/api/reviews.js
+++ b/api/reviews.js
@@ -68,7 +68,6 @@ export default async function handler(req, res) {
   }
 
   const redactedKey = `${apiKey.slice(0, 6)}...`;
-  console.log("Google Places key prefix:", redactedKey);
 
   const requestUrl = new URL(`${GOOGLE_PLACES_BASE_URL}/${encodeURIComponent(placeId)}`);
   requestUrl.searchParams.set("languageCode", "fr");
@@ -87,12 +86,13 @@ export default async function handler(req, res) {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      console.error("Google Places API error:", {
-        status: response.status,
-        statusText: response.statusText,
-        bodySnippet: errorText.slice(0, 500),
-      });
+      const errorBody = await response.text();
+      console.error("[GOOGLE ERROR] Status:", response.status);
+      console.error("[GOOGLE ERROR] Body:", errorBody);
+      console.error(
+        "[GOOGLE ERROR] Headers:",
+        Object.fromEntries(response.headers.entries()),
+      );
       return res.status(502).json({ error: "Upstream Google Places API error." });
     }
 

--- a/conditions-utilisation/index.html
+++ b/conditions-utilisation/index.html
@@ -71,8 +71,9 @@
       <a
         class="nav-cta nav-cta--outline"
         href="https://cal.com/elianelarre/appel-decouverte"
-        target="_blank"
-        rel="noopener noreferrer"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
         >Appel découverte</a>
       <button
         type="button"
@@ -89,14 +90,16 @@
     <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
       <ul>
         <li><a href="/#introduction" data-nav-link>Introduction</a></li>
-        <li><a href="/#programme" data-nav-link>Programme</a></li>
+        <li><a href="/offres/offre-1" data-nav-link>Offre 1</a></li>
+        <li><a href="/offres/offre-2" data-nav-link>Offre 2</a></li>
         <li><a href="/#faq" data-nav-link>FAQ</a></li>
       </ul>
       <a
         class="btn btn-primary nav-mobile-cta"
         href="https://cal.com/elianelarre/appel-decouverte"
-        target="_blank"
-        rel="noopener noreferrer"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
         data-nav-link
         >Appel découverte</a
       >
@@ -216,7 +219,11 @@
             </li>
             <li><a href="/#faq">FAQ</a></li>
             <li>
-              <a href="https://cal.com/elianelarre/appel-decouverte" target="_blank" rel="noopener noreferrer"
+              <a
+                href="https://cal.com/elianelarre/appel-decouverte"
+                data-cal-link="elianelarre/appel-decouverte"
+                data-cal-namespace="appel-decouverte"
+                data-cal-config='{"layout":"month_view"}'
                 >Appel découverte</a
               >
             </li>

--- a/index.html
+++ b/index.html
@@ -74,8 +74,9 @@
       <a
         class="nav-cta nav-cta--outline"
         href="https://cal.com/elianelarre/appel-decouverte"
-        target="_blank"
-        rel="noopener noreferrer"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
         >Appel découverte</a>
       <button
         type="button"
@@ -92,14 +93,16 @@
     <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
       <ul>
         <li><a href="#introduction" data-nav-link>Introduction</a></li>
-        <li><a href="#programme" data-nav-link>Programme</a></li>
+        <li><a href="/offres/offre-1" data-nav-link>Offre 1</a></li>
+        <li><a href="/offres/offre-2" data-nav-link>Offre 2</a></li>
         <li><a href="#faq" data-nav-link>FAQ</a></li>
       </ul>
       <a
         class="btn btn-primary nav-mobile-cta"
         href="https://cal.com/elianelarre/appel-decouverte"
-        target="_blank"
-        rel="noopener noreferrer"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
         data-nav-link
         >Appel découverte</a
       >
@@ -124,8 +127,9 @@
             <a
               class="btn btn-primary"
               href="https://cal.com/elianelarre/appel-decouverte"
-              target="_blank"
-              rel="noopener noreferrer"
+              data-cal-link="elianelarre/appel-decouverte"
+              data-cal-namespace="appel-decouverte"
+              data-cal-config='{"layout":"month_view"}'
               >Appel découverte</a>
             <a class="btn btn-ghost hero-secondary-cta" href="#presentiel"
               >Pourquoi le présentiel<span class="hero-ghost-arrow" aria-hidden="true">→</span></a>
@@ -291,8 +295,9 @@
             <a
               class="btn cta-inline-btn"
               href="https://cal.com/elianelarre/appel-decouverte"
-              target="_blank"
-              rel="noopener noreferrer"
+              data-cal-link="elianelarre/appel-decouverte"
+              data-cal-namespace="appel-decouverte"
+              data-cal-config='{"layout":"month_view"}'
               >OUI, JE VEUX EN SAVOIR PLUS&nbsp;!</a
             >
             <p class="cta-inline-reassure">Gratuit et sans engagement</p>
@@ -401,8 +406,9 @@
                 <a
                   class="fit-bridge-yes-badge"
                   href="https://cal.com/elianelarre/appel-decouverte"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  data-cal-link="elianelarre/appel-decouverte"
+                  data-cal-namespace="appel-decouverte"
+                  data-cal-config='{"layout":"month_view"}'
                 >
                   <span class="fit-bridge-yes-badge__text"
                     >C'est pour <br aria-hidden="true" />moi&nbsp;!</span
@@ -651,8 +657,9 @@
                 <a
                   class="btn btn-primary"
                   href="https://cal.com/elianelarre/appel-decouverte"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  data-cal-link="elianelarre/appel-decouverte"
+                  data-cal-namespace="appel-decouverte"
+                  data-cal-config='{"layout":"month_view"}'
                   >TROUVE LA BONNE APPROCHE</a
                 >
               </div>
@@ -811,8 +818,9 @@
             <a
               class="btn btn-gold"
               href="https://cal.com/elianelarre/appel-decouverte"
-              target="_blank"
-              rel="noopener noreferrer"
+              data-cal-link="elianelarre/appel-decouverte"
+              data-cal-namespace="appel-decouverte"
+              data-cal-config='{"layout":"month_view"}'
               >Appel découverte</a
             >
             <span class="cta-note">Sans engagement</span>
@@ -921,8 +929,9 @@
             <a
               class="btn btn-primary"
               href="https://cal.com/elianelarre/appel-decouverte"
-              target="_blank"
-              rel="noopener noreferrer"
+              data-cal-link="elianelarre/appel-decouverte"
+              data-cal-namespace="appel-decouverte"
+              data-cal-config='{"layout":"month_view"}'
               >Appel découverte</a
             >
             <span class="close-note">Aucun engagement</span>
@@ -952,7 +961,11 @@
             </li>
             <li><a href="#faq">FAQ</a></li>
             <li>
-              <a href="https://cal.com/elianelarre/appel-decouverte" target="_blank" rel="noopener noreferrer"
+              <a
+                href="https://cal.com/elianelarre/appel-decouverte"
+                data-cal-link="elianelarre/appel-decouverte"
+                data-cal-namespace="appel-decouverte"
+                data-cal-config='{"layout":"month_view"}'
                 >Appel découverte</a
               >
             </li>

--- a/politique-de-confidentialite/index.html
+++ b/politique-de-confidentialite/index.html
@@ -74,8 +74,9 @@
       <a
         class="nav-cta nav-cta--outline"
         href="https://cal.com/elianelarre/appel-decouverte"
-        target="_blank"
-        rel="noopener noreferrer"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
         >Appel découverte</a>
       <button
         type="button"
@@ -92,14 +93,16 @@
     <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
       <ul>
         <li><a href="/#introduction" data-nav-link>Introduction</a></li>
-        <li><a href="/#programme" data-nav-link>Programme</a></li>
+        <li><a href="/offres/offre-1" data-nav-link>Offre 1</a></li>
+        <li><a href="/offres/offre-2" data-nav-link>Offre 2</a></li>
         <li><a href="/#faq" data-nav-link>FAQ</a></li>
       </ul>
       <a
         class="btn btn-primary nav-mobile-cta"
         href="https://cal.com/elianelarre/appel-decouverte"
-        target="_blank"
-        rel="noopener noreferrer"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
         data-nav-link
         >Appel découverte</a
       >
@@ -247,7 +250,11 @@
             </li>
             <li><a href="/#faq">FAQ</a></li>
             <li>
-              <a href="https://cal.com/elianelarre/appel-decouverte" target="_blank" rel="noopener noreferrer"
+              <a
+                href="https://cal.com/elianelarre/appel-decouverte"
+                data-cal-link="elianelarre/appel-decouverte"
+                data-cal-namespace="appel-decouverte"
+                data-cal-config='{"layout":"month_view"}'
                 >Appel découverte</a
               >
             </li>

--- a/src/cal-embed.js
+++ b/src/cal-embed.js
@@ -1,0 +1,164 @@
+/**
+ * Cal.com vanilla embed (popup modal on elements with data-cal-link).
+ * Loader pattern from Cal embed-core; script: https://app.cal.com/embed/embed.js
+ */
+
+const CAL_EMBED_SRC = "https://app.cal.com/embed/embed.js";
+const CAL_NAMESPACE = "appel-decouverte";
+/** Viewports below this use Cal `column_view`; at or above use `month_view`. */
+const CAL_LAYOUT_BREAKPOINT_PX = 768;
+
+function installCalQueueSnippet() {
+  const C = window;
+  const A = CAL_EMBED_SRC;
+  const L = "init";
+  const p = (a, ar) => {
+    a.q.push(ar);
+  };
+  const d = C.document;
+  C.Cal =
+    C.Cal ||
+    function () {
+      const cal = C.Cal;
+      const ar = arguments;
+      if (!cal.loaded) {
+        cal.ns = {};
+        cal.q = cal.q || [];
+        d.head.appendChild(d.createElement("script")).src = A;
+        cal.loaded = true;
+      }
+      if (ar[0] === L) {
+        const api = function () {
+          p(api, arguments);
+        };
+        const namespace = ar[1];
+        api.q = api.q || [];
+        if (typeof namespace === "string") {
+          cal.ns[namespace] = cal.ns[namespace] || api;
+          p(cal.ns[namespace], ar);
+          p(cal, ["initNamespace", namespace]);
+        } else p(cal, ar);
+        return;
+      }
+      p(cal, ar);
+    };
+}
+
+/** @param {string} tokenName e.g. "--plum" */
+function cssToken(tokenName) {
+  return getComputedStyle(document.documentElement).getPropertyValue(tokenName).trim();
+}
+
+function resolveCalModalLayout() {
+  return window.innerWidth < CAL_LAYOUT_BREAKPOINT_PX ? "column_view" : "month_view";
+}
+
+function buildCalUiConfig() {
+  const brandColor = cssToken("--plum");
+  const cssVars = {
+    "cal-brand": cssToken("--plum"),
+    "cal-text": cssToken("--ink"),
+    "cal-text-secondary": cssToken("--mid"),
+    "cal-bg": cssToken("--beige"),
+    "cal-border": cssToken("--lavender"),
+  };
+  const shared = { ...cssVars };
+  return {
+    theme: "light",
+    layout: resolveCalModalLayout(),
+    styles: {
+      branding: {
+        brandColor,
+      },
+    },
+    cssVarsPerTheme: {
+      light: { ...shared },
+      dark: { ...shared },
+    },
+  };
+}
+
+if (!window.__ELIANE_CAL_EMBED_INIT__) {
+  window.__ELIANE_CAL_EMBED_INIT__ = true;
+  installCalQueueSnippet();
+  window.Cal("init", CAL_NAMESPACE, { origin: "https://cal.com" });
+  const ns = window.Cal.ns[CAL_NAMESPACE];
+  if (typeof ns === "function") {
+    ns("ui", buildCalUiConfig());
+  }
+}
+
+const DEFAULT_CAL_LINK = "elianelarre/appel-decouverte";
+const DEFAULT_CAL_NAMESPACE = "appel-decouverte";
+const DEFAULT_CAL_CONFIG = { layout: "month_view" };
+
+function parseCalConfig(raw) {
+  if (!raw || typeof raw !== "string") return { ...DEFAULT_CAL_CONFIG };
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { ...DEFAULT_CAL_CONFIG, ...parsed };
+    }
+    return { ...DEFAULT_CAL_CONFIG };
+  } catch {
+    return { ...DEFAULT_CAL_CONFIG };
+  }
+}
+
+function stripNewTabAttrs(el) {
+  el.removeAttribute("target");
+  const rel = el.getAttribute("rel");
+  if (rel && rel.includes("noopener")) {
+    el.removeAttribute("rel");
+  }
+}
+
+function queryCalModalTriggers() {
+  const list = document.querySelectorAll(
+    "a[data-cal-link], button[data-cal-link], [data-cal-link]",
+  );
+  return [...new Set(list)];
+}
+
+function bindCalModalClickHandlers() {
+  if (window.__ELIANE_CAL_MODAL_HANDLERS_BOUND__) return;
+  window.__ELIANE_CAL_MODAL_HANDLERS_BOUND__ = true;
+
+  queryCalModalTriggers().forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+    stripNewTabAttrs(el);
+
+    el.addEventListener(
+      "click",
+      (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        stripNewTabAttrs(el);
+
+        const calLink = el.dataset.calLink || DEFAULT_CAL_LINK;
+        const namespace = el.dataset.calNamespace || DEFAULT_CAL_NAMESPACE;
+        const config = {
+          ...parseCalConfig(el.dataset.calConfig),
+          layout: resolveCalModalLayout(),
+        };
+
+        const api = window.Cal?.ns?.[namespace];
+        if (typeof api !== "function") return;
+
+        api("modal", { calLink, config });
+      },
+      false,
+    );
+  });
+}
+
+function scheduleCalModalBinding() {
+  const run = () => bindCalModalClickHandlers();
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", run, { once: true });
+  } else {
+    run();
+  }
+}
+
+scheduleCalModalBinding();

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import './style.css';
+import './cal-embed.js';
 import { initIntroPhotoDock } from './intro-photo-dock.js';
 import { initCookieConsent } from './cookie-consent.js';
 import { createIcons } from 'lucide';
@@ -6,8 +7,6 @@ import Eye from 'lucide/dist/esm/icons/eye.js';
 import ShieldCheck from 'lucide/dist/esm/icons/shield-check.js';
 import CalendarCheck from 'lucide/dist/esm/icons/calendar-check.js';
 import Activity from 'lucide/dist/esm/icons/activity.js';
-
-const BOOKING_HREF = 'https://cal.com/elianelarre/appel-decouverte';
 
 /** Biner Training — 220 Bd Crémazie O; center matches Google Maps place resolution for maps.app.goo.gl/c1V1Re3Guj8ZF6mEA */
 const BINER_STATIC_MAP_CENTER = '45.5385897,-73.6430173';
@@ -242,12 +241,6 @@ function initNav(nav) {
   });
 
   initNavDesktopDropdowns(nav);
-
-  // Ensure booking CTA links are consistent (sanity check in dev)
-  document.querySelectorAll(`a[href="${BOOKING_HREF}"]`).forEach((a) => {
-    a.setAttribute('rel', 'noopener noreferrer');
-    if (!a.getAttribute('target')) a.setAttribute('target', '_blank');
-  });
 }
 
 function initReveal() {

--- a/src/style.css
+++ b/src/style.css
@@ -102,7 +102,7 @@ button:focus-visible {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 100;
+  z-index: 500;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -205,7 +205,7 @@ button:focus-visible {
   position: absolute;
   top: 100%;
   left: 50%;
-  z-index: 110;
+  z-index: 520;
   min-width: 11rem;
   padding-top: 0.35rem;
   transform: translateX(-50%) translateY(-6px);
@@ -350,6 +350,7 @@ button:focus-visible {
   top: var(--nav-h);
   left: 0;
   right: 0;
+  z-index: 510;
   padding: 1.25rem var(--pad-x) 1.5rem;
   background: var(--white);
   border-bottom: 1px solid rgba(26, 20, 16, 0.08);
@@ -2810,4 +2811,18 @@ button:focus-visible {
     transform: none;
   }
 
+}
+
+/* —— Cal.com embed modal —— above fixed .site-nav (z-index: 500) and nav dropdown (520) */
+cal-modal-box,
+cal-modal-box * {
+  z-index: 99999 !important;
+}
+
+/*
+ * Cal may set data-cal-namespace on injected hosts. Exclude our booking <a>/<button>
+ * (they use the same attribute) so we do not alter their stacking.
+ */
+[data-cal-namespace="appel-decouverte"]:not(a):not(button) {
+  z-index: 99999 !important;
 }


### PR DESCRIPTION
## Summary
- Adds `api/reviews.js` Vercel serverless GET endpoint for Google Places API v1 place reviews.
- Sanitizes upstream response to return only `rating`, `reviewCount`, `googleMapsUrl`, and mapped `reviews` fields.
- Adds timeout, upstream error handling, CORS headers, and edge cache headers to reduce API costs.
- Ensures `.gitignore` includes `.env.local` and `.env*.local` patterns.

Closes #37

## How I verified
- Ran `npx vercel dev --yes`.
- Called `curl -i http://localhost:3000/api/reviews` and confirmed valid JSON error response when env vars are missing:
  - HTTP 500 with `{"error":"Server configuration error: missing GOOGLE_PLACES_API_KEY or GOOGLE_PLACE_ID."}`
  - `Cache-Control`, `Access-Control-Allow-Origin`, and `Access-Control-Allow-Methods` headers present.
- Called `curl -i -X POST http://localhost:3000/api/reviews` and confirmed HTTP 405 JSON response.
- Confirmed API key is never returned in response payload.

## Notes
- Local verification of live Google review payload is currently blocked until `GOOGLE_PLACES_API_KEY` and `GOOGLE_PLACE_ID` are set in local server runtime env for `vercel dev`.