### PR TITLE
Homepage Les offres section, nav/hero/footer (#39)

### DIFF
--- a/conditions-utilisation/index.html
+++ b/conditions-utilisation/index.html
@@ -22,8 +22,8 @@
         <ul class="nav-desktop">
           <li><a href="/#introduction">Introduction</a></li>
           <li class="nav-dropdown" data-nav-dropdown>
-            <button
-              type="button"
+            <a
+              href="/#offres"
               class="nav-dropdown-trigger"
               id="nav-offres-trigger"
               data-nav-dropdown-trigger
@@ -31,7 +31,7 @@
               aria-haspopup="menu"
               aria-controls="nav-offres-menu"
             >
-              <span class="nav-dropdown-trigger__label">Offres</span>
+              Offres
               <svg
                 class="nav-dropdown-chevron"
                 width="12"
@@ -50,7 +50,7 @@
                   stroke-linejoin="round"
                 />
               </svg>
-            </button>
+            </a>
             <div
               class="nav-dropdown-panel"
               id="nav-offres-menu"
@@ -60,8 +60,12 @@
               hidden
             >
               <div class="nav-dropdown-panel__surface">
-                <a href="/offres/offre-1" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 1</a>
-                <a href="/offres/offre-2" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 2</a>
+                <a href="/offres/le-tremplin" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 1 — Le Tremplin</a
+                >
+                <a href="/offres/offre-signature" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 2 — Offre signature</a
+                >
               </div>
             </div>
           </li>
@@ -90,8 +94,9 @@
     <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
       <ul>
         <li><a href="/#introduction" data-nav-link>Introduction</a></li>
-        <li><a href="/offres/offre-1" data-nav-link>Offre 1</a></li>
-        <li><a href="/offres/offre-2" data-nav-link>Offre 2</a></li>
+        <li><a href="/#offres" data-nav-link>Offres</a></li>
+        <li><a href="/offres/le-tremplin" data-nav-link>Offre 1 — Le Tremplin</a></li>
+        <li><a href="/offres/offre-signature" data-nav-link>Offre 2 — Offre signature</a></li>
         <li><a href="/#faq" data-nav-link>FAQ</a></li>
       </ul>
       <a
@@ -211,10 +216,10 @@
           <ul class="footer-links">
             <li><a href="/#introduction">Introduction</a></li>
             <li>
-              <a href="/#programme">Offres</a>
+              <a href="/#offres">Offres</a>
               <ul class="footer-sublinks">
-                <li><a href="/offres/offre-1">Offre 1</a></li>
-                <li><a href="/offres/offre-2">Offre 2</a></li>
+                <li><a href="/offres/le-tremplin">Offre 1 — Le Tremplin</a></li>
+                <li><a href="/offres/offre-signature">Offre 2 — Offre signature</a></li>
               </ul>
             </li>
             <li><a href="/#faq">FAQ</a></li>

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
         <ul class="nav-desktop">
           <li><a href="#introduction">Introduction</a></li>
           <li class="nav-dropdown" data-nav-dropdown>
-            <button
-              type="button"
+            <a
+              href="#offres"
               class="nav-dropdown-trigger"
               id="nav-offres-trigger"
               data-nav-dropdown-trigger
@@ -34,7 +34,7 @@
               aria-haspopup="menu"
               aria-controls="nav-offres-menu"
             >
-              <span class="nav-dropdown-trigger__label">Offres</span>
+              Offres
               <svg
                 class="nav-dropdown-chevron"
                 width="12"
@@ -53,7 +53,7 @@
                   stroke-linejoin="round"
                 />
               </svg>
-            </button>
+            </a>
             <div
               class="nav-dropdown-panel"
               id="nav-offres-menu"
@@ -63,8 +63,12 @@
               hidden
             >
               <div class="nav-dropdown-panel__surface">
-                <a href="/offres/offre-1" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 1</a>
-                <a href="/offres/offre-2" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 2</a>
+                <a href="/offres/le-tremplin" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 1 — Le Tremplin</a
+                >
+                <a href="/offres/offre-signature" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 2 — Offre signature</a
+                >
               </div>
             </div>
           </li>
@@ -93,8 +97,9 @@
     <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
       <ul>
         <li><a href="#introduction" data-nav-link>Introduction</a></li>
-        <li><a href="/offres/offre-1" data-nav-link>Offre 1</a></li>
-        <li><a href="/offres/offre-2" data-nav-link>Offre 2</a></li>
+        <li><a href="#offres" data-nav-link>Offres</a></li>
+        <li><a href="/offres/le-tremplin" data-nav-link>Offre 1 — Le Tremplin</a></li>
+        <li><a href="/offres/offre-signature" data-nav-link>Offre 2 — Offre signature</a></li>
         <li><a href="#faq" data-nav-link>FAQ</a></li>
       </ul>
       <a
@@ -131,8 +136,8 @@
               data-cal-namespace="appel-decouverte"
               data-cal-config='{"layout":"month_view"}'
               >Appel découverte</a>
-            <a class="btn btn-ghost hero-secondary-cta" href="#presentiel"
-              >Pourquoi le présentiel<span class="hero-ghost-arrow" aria-hidden="true">→</span></a>
+            <a class="btn btn-ghost hero-secondary-cta" href="#offres"
+              >Voir les offres<span class="hero-ghost-arrow" aria-hidden="true">→</span></a>
           </div>
         </div>
         <div class="hero-visual">
@@ -668,140 +673,77 @@
         </div>
       </section>
 
-      <section class="section section-warm" id="programme">
-        <div class="section-inner">
-          <div class="programme-head">
-            <div class="reveal" data-reveal>
-              <span class="eyebrow">Le programme en détail</span>
-              <h2>12 semaines structurées<br /><em>autour de ta progression</em></h2>
-            </div>
-            <div class="media-frame reveal" data-reveal>
-              <img
-                src="/images/hero-6.png"
-                alt="Éliane en mouvement de tirage, dos et bras engagés."
-                width="400"
-                height="533"
-                loading="lazy"
-              />
-            </div>
-          </div>
-          <div class="prog-steps">
-            <article class="prog-step reveal" data-reveal>
-              <div class="prog-side">
-                <p class="prog-tag">Séance 1 · 2 heures</p>
-                <h3>On part de toi, pas d'un modèle</h3>
-              </div>
-              <div class="prog-body">
-                <p>Une première séance complète dédiée à établir ton point de départ avec précision.</p>
-                <ul class="prog-list">
-                  <li>Évaluation complète de ta condition physique</li>
-                  <li>Tests VO₂ max et tests de force</li>
-                  <li>Collecte de données corporelles (poids, masse grasse, masse musculaire)</li>
-                  <li>Photos de départ</li>
-                  <li>Présentation de ton programme personnalisé</li>
-                  <li>Plan de match pour ta première semaine</li>
+      <section class="section section-warm section-offres" id="offres">
+        <div class="section-inner section-inner--offres">
+          <header class="offres-head reveal" data-reveal>
+            <span class="eyebrow">Les offres</span>
+            <h2>Choisis l'offre <em>qui correspond à ton parcours</em></h2>
+            <p class="offres-lead">Deux formules conçues selon ton niveau et tes objectifs.</p>
+          </header>
+          <div class="offres-grid">
+            <article class="offres-card offres-card--tremplin reveal" data-reveal>
+              <span class="offres-badge offres-badge--muted" aria-hidden="true">1 mois</span>
+              <div class="offres-card__body">
+                <h3 class="offres-card__title">Le Tremplin</h3>
+                <p class="offres-card__duration">1 mois</p>
+                <p class="offres-card__pitch">Pour démarrer avec un plan clair et un encadrement de proximité.</p>
+                <ul class="offres-feature-list">
+                  <li>1 rencontre en présentiel de 2 heures</li>
+                  <li>Programme d'entraînement personnalisé</li>
+                  <li>Accès à l'application de suivi</li>
+                  <li>Messagerie directe 7/7 pendant 4 semaines</li>
+                  <li>Appel bilan de 45 minutes</li>
                 </ul>
+                <div class="offres-ideal">
+                  <p class="offres-ideal__label">IDÉALE SI TU…</p>
+                  <p class="offres-ideal__text">t'entraînes déjà mais manques de structure.</p>
+                </div>
+              </div>
+              <div class="offres-card__cta">
+                <a class="btn btn-primary btn--offres-cta" href="/offres/le-tremplin">En savoir plus<span aria-hidden="true"> →</span></a>
               </div>
             </article>
-            <article class="prog-step reveal" data-reveal>
-              <div class="prog-side">
-                <p class="prog-tag">Séances 2 à 11 · 1 heure</p>
-                <h3>On avance ensemble, semaine après semaine</h3>
-              </div>
-              <div class="prog-body">
-                <p>Chaque séance est construite autour de ta semaine — pas d'un plan figé.</p>
-                <ul class="prog-list">
-                  <li>Check-in hebdomadaire avant chaque séance</li>
-                  <li>Retour sur ton sommeil, ton énergie et ta récupération</li>
-                  <li>Entraînement privé avec correction de technique</li>
-                  <li>Ajustements du programme selon ton évolution</li>
-                  <li>Support illimité entre les séances</li>
+            <article
+              class="offres-card offres-card--signature reveal"
+              data-reveal
+              aria-label="Offre signature — offre recommandée"
+            >
+              <span class="offres-badge offres-badge--popular">Populaire</span>
+              <div class="offres-card__body">
+                <h3 class="offres-card__title">Offre signature</h3>
+                <p class="offres-card__duration">3 mois</p>
+                <p class="offres-card__pitch">Pour un accompagnement complet, structuré et personnalisé.</p>
+                <ul class="offres-feature-list">
+                  <li>12 séances en présentiel (1 par semaine)</li>
+                  <li>Programme d'entraînement personnalisé</li>
+                  <li>Accès à l'application de suivi</li>
+                  <li>Messagerie directe 7/7 pendant 12 semaines</li>
+                  <li>1 semaine de journal alimentaire</li>
+                  <li>Bilan écrit final avec recommandations</li>
                 </ul>
+                <div class="offres-ideal">
+                  <p class="offres-ideal__label">IDÉALE SI TU…</p>
+                  <p class="offres-ideal__text">veux une transformation complète avec encadrement hebdomadaire.</p>
+                </div>
               </div>
-            </article>
-            <article class="prog-step reveal" data-reveal>
-              <div class="prog-side">
-                <p class="prog-tag">Séance 12 · 2 heures</p>
-                <h3>On mesure. On célèbre. On planifie la suite.</h3>
-              </div>
-              <div class="prog-body">
-                <p>Un bilan complet pour voir le chemin parcouru et définir la prochaine étape.</p>
-                <ul class="prog-list">
-                  <li>Bilan des 12 semaines</li>
-                  <li>Tests physiques finaux vs données initiales</li>
-                  <li>Photos finales et comparaison visuelle</li>
-                  <li>Discussion sur la suite selon tes objectifs</li>
-                </ul>
+              <div class="offres-card__cta">
+                <a class="btn btn-primary btn--offres-cta" href="/offres/offre-signature"
+                  >En savoir plus<span aria-hidden="true"> →</span></a
+                >
               </div>
             </article>
           </div>
-        </div>
-      </section>
-
-      <section class="section section-muted">
-        <div class="section-inner">
-          <div class="inclus-layout">
-            <div>
-              <div class="reveal" data-reveal>
-                <span class="eyebrow">Ce qui est inclus</span>
-                <h2>Tout est prévu.<br /><em>Rien n'est laissé au hasard.</em></h2>
-              </div>
-              <div class="incl-grid" style="margin-top: 2rem">
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">01</p>
-                  <h3>12 séances privées en présentiel</h3>
-                  <p>14 heures au total au Biner Training, Montréal. Séances de 2h la première et la dernière semaine.</p>
-                </div>
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">02</p>
-                  <h3>Programme d'entraînement personnalisé</h3>
-                  <p>Adapté à tes objectifs et ton équipement. Mis à jour en continu selon ta progression.</p>
-                </div>
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">03</p>
-                  <h3>Analyse de ton alimentation</h3>
-                  <p>Des recommandations réalistes sans restriction ni culpabilité.</p>
-                </div>
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">04</p>
-                  <h3>Suivi de composition corporelle</h3>
-                  <p>Masse grasse, masse musculaire, poids, IMC — mesurés au départ et à la fin.</p>
-                </div>
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">05</p>
-                  <h3>Application fitness privée</h3>
-                  <p>Programme, calendrier, journal alimentaire, mesures et échanges centralisés.</p>
-                </div>
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">06</p>
-                  <h3>Accès illimité 7 jours sur 7</h3>
-                  <p>Questions et ajustements rapides — tu n'es jamais seule entre les séances.</p>
-                </div>
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">07</p>
-                  <h3>3 séances bonus</h3>
-                  <p>En échange de service, échangeables contre des soins esthétiques.</p>
-                </div>
-                <div class="incl-item reveal" data-reveal>
-                  <p class="incl-n">08</p>
-                  <h3>Groupe privé de contenu</h3>
-                  <p>Contenu pertinent partagé régulièrement pour soutenir ta progression.</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="media-frame media-frame--inclus-banner reveal"
-            data-reveal
-            style="max-width: 100%; margin-top: 2rem; aspect-ratio: 21 / 9"
-          >
-            <img
-              src="/images/hero-8.png"
-              alt="Éliane en séance au sol sur banc, gainage et contrôle du tronc."
-              width="1200"
-              height="514"
-              loading="lazy"
-            />
+          <div class="offres-helper reveal" data-reveal>
+            <p class="offres-helper__line">Tu hésites entre les deux ?</p>
+            <p class="offres-helper__sub">Parlons-en lors d'un appel découverte.</p>
+            <a
+              class="btn btn-primary"
+              href="https://cal.com/elianelarre/appel-decouverte"
+              data-cal-link="elianelarre/appel-decouverte"
+              data-cal-namespace="appel-decouverte"
+              data-cal-config='{"layout":"month_view"}'
+              >Réserver un appel</a
+            >
           </div>
         </div>
       </section>
@@ -953,10 +895,10 @@
           <ul class="footer-links">
             <li><a href="#introduction">Introduction</a></li>
             <li>
-              <a href="#programme">Offres</a>
+              <a href="#offres">Offres</a>
               <ul class="footer-sublinks">
-                <li><a href="/offres/offre-1">Offre 1</a></li>
-                <li><a href="/offres/offre-2">Offre 2</a></li>
+                <li><a href="/offres/le-tremplin">Offre 1 — Le Tremplin</a></li>
+                <li><a href="/offres/offre-signature">Offre 2 — Offre signature</a></li>
               </ul>
             </li>
             <li><a href="#faq">FAQ</a></li>

--- a/offres/le-tremplin/index.html
+++ b/offres/le-tremplin/index.html
@@ -1,0 +1,376 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Une formule d'un mois pour démarrer avec structure, clarté et accompagnement."
+    />
+    <title>Le Tremplin — Éliane Larre</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Poppins:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="offer-page">
+    <a class="skip-link" href="#contenu-principal">Passer au contenu</a>
+
+    <header class="site-nav" id="site-nav" data-nav>
+      <a class="nav-logo" href="/#accueil" aria-label="Éliane Larre — Accueil"><em>Éliane Larre</em></a>
+      <nav aria-label="Navigation principale">
+        <ul class="nav-desktop">
+          <li><a href="/#introduction">Introduction</a></li>
+          <li class="nav-dropdown" data-nav-dropdown>
+            <a
+              href="/#offres"
+              class="nav-dropdown-trigger"
+              id="nav-offres-trigger"
+              data-nav-dropdown-trigger
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-controls="nav-offres-menu"
+            >
+              Offres
+              <svg
+                class="nav-dropdown-chevron"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M6 9l6 6 6-6"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </a>
+            <div
+              class="nav-dropdown-panel"
+              id="nav-offres-menu"
+              data-nav-dropdown-panel
+              role="menu"
+              aria-labelledby="nav-offres-trigger"
+              hidden
+            >
+              <div class="nav-dropdown-panel__surface">
+                <a href="/offres/le-tremplin" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 1 — Le Tremplin</a
+                >
+                <a href="/offres/offre-signature" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 2 — Offre signature</a
+                >
+              </div>
+            </div>
+          </li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+      </nav>
+      <a
+        class="nav-cta nav-cta--outline"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
+        >Appel découverte</a>
+      <button
+        type="button"
+        class="nav-toggle"
+        aria-expanded="false"
+        aria-controls="nav-mobile"
+        data-nav-toggle
+        aria-label="Ouvrir le menu"
+      >
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+    </header>
+
+    <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
+      <ul>
+        <li><a href="/#introduction" data-nav-link>Introduction</a></li>
+        <li><a href="/#offres" data-nav-link>Offres</a></li>
+        <li><a href="/offres/le-tremplin" data-nav-link>Offre 1 — Le Tremplin</a></li>
+        <li><a href="/offres/offre-signature" data-nav-link>Offre 2 — Offre signature</a></li>
+        <li><a href="/#faq" data-nav-link>FAQ</a></li>
+      </ul>
+      <a
+        class="btn btn-primary nav-mobile-cta"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
+        data-nav-link
+        >Appel découverte</a
+      >
+    </div>
+
+    <main id="contenu-principal" class="offer-main">
+      <section class="offer-hero">
+        <div class="offer-hero-inner">
+          <a class="offer-back-link" href="/#offres">← Retour aux offres</a>
+          <p class="offer-hero-eyebrow">Formule 1 mois</p>
+          <h1 class="offer-hero-title">Le Tremplin</h1>
+          <p class="offer-hero-subtitle">
+            <em>Pour démarrer avec structure, clarté et accompagnement.</em>
+          </p>
+          <p class="offer-hero-pitch">
+            Une formule d'un mois pensée pour celles qui veulent démarrer avec un plan clair, personnalisé et un
+            encadrement de proximité. Tu bénéficies d'une rencontre initiale en présentiel de 2 heures, de ton programme
+            d'entraînement personnalisé, d'un accès à moi 7/7 par message durant 4 semaines, d'ajustements de ton
+            programme au besoin, ainsi que d'un appel bilan de 45 minutes en fin de mois.
+          </p>
+          <div class="offer-hero-actions">
+            <a
+              class="btn btn-primary"
+              href="https://cal.com/elianelarre/appel-decouverte"
+              data-cal-link="elianelarre/appel-decouverte"
+              data-cal-namespace="appel-decouverte"
+              data-cal-config='{"layout":"month_view"}'
+              >Appel découverte</a
+            >
+            <a class="arrow-text-link offer-hero-secondary" href="#comparaison"
+              >Comparer les offres<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section class="offer-section offer-section--muted" aria-labelledby="offer-ideal-heading">
+        <div class="offer-section-inner">
+          <p class="eyebrow">Pour qui</p>
+          <h2 class="offer-section-title" id="offer-ideal-heading">Cette offre est idéale si tu veux…</h2>
+          <ul class="offres-feature-list offer-list-block">
+            <li>Avoir un programme personnalisé à tes objectifs</li>
+            <li>Avoir accès à moi 7/7 via messages pour tes questions et ajustements</li>
+            <li>Bâtir une base solide avant de poursuivre de façon plus autonome</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="offer-section" aria-labelledby="offer-includes-heading">
+        <div class="offer-section-inner offer-section-inner--wide">
+          <p class="eyebrow">Ce que tu reçois</p>
+          <h2 class="offer-section-title" id="offer-includes-heading">Ce que comprend l'offre</h2>
+          <div class="offer-includes-grid">
+            <div class="offer-include-group">
+              <p class="offer-include-label" id="offer-inc-rencontre">La rencontre</p>
+              <ul class="offres-feature-list" aria-labelledby="offer-inc-rencontre">
+                <li>1 rencontre initiale en présentiel de 2 heures</li>
+                <li>Présentation et ajustements du programme d'entraînement</li>
+              </ul>
+            </div>
+            <div class="offer-include-group">
+              <p class="offer-include-label" id="offer-inc-programme">Le programme</p>
+              <ul class="offres-feature-list" aria-labelledby="offer-inc-programme">
+                <li>Programme d'entraînement personnalisé</li>
+                <li>Ajustable durant les 4 semaines selon tes commentaires et résultats</li>
+                <li>Tests physiques et mesures de départ</li>
+                <li>Prises de la composition corporelle</li>
+              </ul>
+            </div>
+            <div class="offer-include-group">
+              <p class="offer-include-label" id="offer-inc-app">L'application</p>
+              <ul class="offres-feature-list" aria-labelledby="offer-inc-app">
+                <li>Accès à ton programme</li>
+                <li>Suivi de tes charges</li>
+                <li>Messagerie directe 7/7</li>
+                <li>Questionnaire « check-in de la semaine » chaque semaine</li>
+                <li>Ajustements du programme au besoin via tes commentaires</li>
+              </ul>
+            </div>
+            <div class="offer-include-group">
+              <p class="offer-include-label" id="offer-inc-bilan">Le bilan</p>
+              <ul class="offres-feature-list" aria-labelledby="offer-inc-bilan">
+                <li>1 appel bilan de 45 minutes à la fin des 4 semaines</li>
+                <li>Questionnaire préalablement complété</li>
+                <li>Résumé et recommandations pour la suite</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="offer-section offer-section--muted" aria-labelledby="offer-for-you-heading">
+        <div class="offer-section-inner">
+          <p class="eyebrow">Tu te reconnais ?</p>
+          <h2 class="offer-section-title" id="offer-for-you-heading">Cette offre est pour toi si…</h2>
+          <ul class="offres-feature-list offer-list-block">
+            <li>Tu t'entraînes déjà, mais tu manques de structure</li>
+            <li>Tu veux avoir accès à ton entraîneure pour répondre à toutes tes questions 7 jours sur 7</li>
+            <li>Tu es constante depuis plusieurs mois ou années</li>
+            <li>Tu n'as pas besoin d'une séance en présentiel chaque semaine pour progresser</li>
+            <li>Tu es capable d'exécuter tes entraînements de façon autonome</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="offer-section" id="comparaison" aria-labelledby="offer-compare-heading">
+        <div class="offer-section-inner">
+          <p class="eyebrow">Comparaison</p>
+          <h2 class="offer-section-title" id="offer-compare-heading">Comparer les deux offres</h2>
+
+          <div class="offer-compare" data-offer-compare>
+            <button
+              type="button"
+              class="offer-compare-toggle"
+              data-offer-compare-toggle
+              aria-expanded="false"
+              aria-controls="offer-compare-panel"
+              id="offer-compare-btn"
+            >
+              <span class="offer-compare-toggle__text">Afficher la comparaison</span>
+              <svg
+                class="offer-compare-chevron"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M6 9l6 6 6-6"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <div
+              class="offer-compare-panel-wrap"
+              data-offer-compare-panel-wrap
+              aria-hidden="true"
+              id="offer-compare-panel"
+              role="region"
+              aria-labelledby="offer-compare-btn"
+            >
+              <div class="offer-compare-panel-inner">
+                <div class="offer-compare-columns">
+                  <div class="offer-compare-col offer-compare-col--current">
+                    <p class="offer-compare-kicker offer-compare-kicker--current">Offre actuelle</p>
+                    <h3 class="offer-compare-col-title">Le Tremplin</h3>
+                    <p class="offer-compare-col-sub">1 mois</p>
+                    <ul class="offres-feature-list offer-compare-list">
+                      <li>Tu t'entraînes déjà ou t'es déjà entraînée dans le passé</li>
+                      <li>Tu es autonome et déjà constante</li>
+                      <li>Tu ne peux pas facilement intégrer du présentiel chaque semaine</li>
+                      <li>Tu veux briser un plateau</li>
+                    </ul>
+                  </div>
+                  <div class="offer-compare-col">
+                    <p class="offer-compare-kicker">Autre offre</p>
+                    <h3 class="offer-compare-col-title">Offre signature</h3>
+                    <p class="offer-compare-col-sub">3 mois</p>
+                    <ul class="offres-feature-list offer-compare-list">
+                      <li>Tu ne t'es jamais entraînée</li>
+                      <li>Tu veux une transformation plus complète</li>
+                      <li>Tu as besoin de plus d'encadrement</li>
+                      <li>Tu veux bénéficier de séances en présentiel</li>
+                      <li>Tu veux être suivie de façon plus rapprochée</li>
+                      <li>Tu veux installer des habitudes solides sur le long terme</li>
+                    </ul>
+                    <a class="arrow-text-link offer-compare-other-link" href="/offres/offre-signature"
+                      >Voir cette offre<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
+                    >
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <a
+      class="offer-sticky-cta"
+      href="https://cal.com/elianelarre/appel-decouverte"
+      data-cal-link="elianelarre/appel-decouverte"
+      data-cal-namespace="appel-decouverte"
+      data-cal-config='{"layout":"month_view"}'
+      data-offer-sticky-cta
+      aria-label="Réserver un appel découverte"
+      aria-hidden="true"
+      tabindex="-1"
+      >Commencer maintenant</a
+    >
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
+          <p class="footer-brand"><em>Éliane Larre</em></p>
+          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-location">Montréal, Québec</p>
+        </section>
+
+        <nav class="footer-col footer-col--nav" aria-label="Navigation pied de page">
+          <h3 class="footer-title">Navigation</h3>
+          <ul class="footer-links">
+            <li><a href="/#introduction">Introduction</a></li>
+            <li>
+              <a href="/#offres">Offres</a>
+              <ul class="footer-sublinks">
+                <li><a href="/offres/le-tremplin">Offre 1 — Le Tremplin</a></li>
+                <li><a href="/offres/offre-signature">Offre 2 — Offre signature</a></li>
+              </ul>
+            </li>
+            <li><a href="/#faq">FAQ</a></li>
+            <li>
+              <a
+                href="https://cal.com/elianelarre/appel-decouverte"
+                data-cal-link="elianelarre/appel-decouverte"
+                data-cal-namespace="appel-decouverte"
+                data-cal-config='{"layout":"month_view"}'
+                >Appel découverte</a
+              >
+            </li>
+          </ul>
+        </nav>
+
+        <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
+          <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
+          <address class="footer-contact-list">
+            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a
+              class="footer-ig-link"
+              href="https://www.instagram.com/eliane.au.naturel"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram @elianelarre (nouvel onglet)"
+            >
+              <svg class="footer-ig-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path
+                  d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zm0 10.162a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 11-2.881 0 1.44 1.44 0 012.881 0z"
+                />
+              </svg>
+            </a>
+          </address>
+        </section>
+
+        <nav class="footer-col footer-col--legal" aria-label="Liens légaux">
+          <h3 class="footer-title">Légal</h3>
+          <ul class="footer-links">
+            <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
+            <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+            <li><a href="#" data-cookie-preferences-link>Gérer mes préférences de témoins</a></li>
+          </ul>
+        </nav>
+      </div>
+      <div class="footer-bottom">
+        <p class="footer-bottom-copy">© 2026 Éliane Larre. Tous droits réservés.</p>
+        <p class="footer-bottom-credit">
+          <a href="https://wfwonder.com/" target="_blank" rel="noopener noreferrer">WorkflowWonder ✦</a>
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/offres/le-tremplin/index.html
+++ b/offres/le-tremplin/index.html
@@ -144,7 +144,7 @@
         </div>
       </section>
 
-      <section class="offer-section offer-section--muted" aria-labelledby="offer-ideal-heading">
+      <section class="offer-section offer-section--warm-sand" aria-labelledby="offer-ideal-heading">
         <div class="offer-section-inner">
           <p class="eyebrow">Pour qui</p>
           <h2 class="offer-section-title" id="offer-ideal-heading">Cette offre est idéale si tu veux…</h2>
@@ -160,50 +160,70 @@
         <div class="offer-section-inner offer-section-inner--wide">
           <p class="eyebrow">Ce que tu reçois</p>
           <h2 class="offer-section-title" id="offer-includes-heading">Ce que comprend l'offre</h2>
-          <div class="offer-includes-grid">
-            <div class="offer-include-group">
-              <p class="offer-include-label" id="offer-inc-rencontre">La rencontre</p>
-              <ul class="offres-feature-list" aria-labelledby="offer-inc-rencontre">
+          <div class="offer-process-grid">
+            <article class="offer-process-card" aria-labelledby="offer-card-01-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">01</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">La rencontre</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-01-title">Rencontre initiale</h3>
+              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-01-title">
                 <li>1 rencontre initiale en présentiel de 2 heures</li>
                 <li>Présentation et ajustements du programme d'entraînement</li>
               </ul>
-            </div>
-            <div class="offer-include-group">
-              <p class="offer-include-label" id="offer-inc-programme">Le programme</p>
-              <ul class="offres-feature-list" aria-labelledby="offer-inc-programme">
+            </article>
+            <article class="offer-process-card" aria-labelledby="offer-card-02-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">02</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">Le programme</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-02-title">Programme personnalisé</h3>
+              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-02-title">
                 <li>Programme d'entraînement personnalisé</li>
                 <li>Ajustable durant les 4 semaines selon tes commentaires et résultats</li>
                 <li>Tests physiques et mesures de départ</li>
                 <li>Prises de la composition corporelle</li>
               </ul>
-            </div>
-            <div class="offer-include-group">
-              <p class="offer-include-label" id="offer-inc-app">L'application</p>
-              <ul class="offres-feature-list" aria-labelledby="offer-inc-app">
+            </article>
+            <article class="offer-process-card" aria-labelledby="offer-card-03-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">03</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">L'application</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-03-title">Accès à l'application</h3>
+              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-03-title">
                 <li>Accès à ton programme</li>
                 <li>Suivi de tes charges</li>
                 <li>Messagerie directe 7/7</li>
                 <li>Questionnaire « check-in de la semaine » chaque semaine</li>
                 <li>Ajustements du programme au besoin via tes commentaires</li>
               </ul>
-            </div>
-            <div class="offer-include-group">
-              <p class="offer-include-label" id="offer-inc-bilan">Le bilan</p>
-              <ul class="offres-feature-list" aria-labelledby="offer-inc-bilan">
+            </article>
+            <article class="offer-process-card" aria-labelledby="offer-card-04-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">04</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">Le bilan</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-04-title">Appel bilan</h3>
+              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-04-title">
                 <li>1 appel bilan de 45 minutes à la fin des 4 semaines</li>
                 <li>Questionnaire préalablement complété</li>
                 <li>Résumé et recommandations pour la suite</li>
               </ul>
-            </div>
+            </article>
           </div>
         </div>
       </section>
 
-      <section class="offer-section offer-section--muted" aria-labelledby="offer-for-you-heading">
+      <section class="offer-section offer-section--plum" aria-labelledby="offer-for-you-heading">
         <div class="offer-section-inner">
           <p class="eyebrow">Tu te reconnais ?</p>
           <h2 class="offer-section-title" id="offer-for-you-heading">Cette offre est pour toi si…</h2>
-          <ul class="offres-feature-list offer-list-block">
+          <ul class="offres-feature-list offer-list-block offres-feature-list--on-plum">
             <li>Tu t'entraînes déjà, mais tu manques de structure</li>
             <li>Tu veux avoir accès à ton entraîneure pour répondre à toutes tes questions 7 jours sur 7</li>
             <li>Tu es constante depuis plusieurs mois ou années</li>

--- a/offres/le-tremplin/index.html
+++ b/offres/le-tremplin/index.html
@@ -116,7 +116,6 @@
     <main id="contenu-principal" class="offer-main">
       <section class="offer-hero">
         <div class="offer-hero-inner">
-          <a class="offer-back-link" href="/#offres">← Retour aux offres</a>
           <p class="offer-hero-eyebrow">Formule 1 mois</p>
           <h1 class="offer-hero-title">Le Tremplin</h1>
           <p class="offer-hero-subtitle">
@@ -168,9 +167,11 @@
                 <p class="offer-process-card__kicker">La rencontre</p>
               </div>
               <h3 class="offer-process-card__title" id="offer-card-01-title">Rencontre initiale</h3>
-              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-01-title">
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-01-title">
                 <li>1 rencontre initiale en présentiel de 2 heures</li>
                 <li>Présentation et ajustements du programme d'entraînement</li>
+                <li>Tests physiques et mesures de départ</li>
+                <li>Prises de la composition corporelle</li>
               </ul>
             </article>
             <article class="offer-process-card" aria-labelledby="offer-card-02-title">
@@ -180,11 +181,9 @@
                 <p class="offer-process-card__kicker">Le programme</p>
               </div>
               <h3 class="offer-process-card__title" id="offer-card-02-title">Programme personnalisé</h3>
-              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-02-title">
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-02-title">
                 <li>Programme d'entraînement personnalisé</li>
                 <li>Ajustable durant les 4 semaines selon tes commentaires et résultats</li>
-                <li>Tests physiques et mesures de départ</li>
-                <li>Prises de la composition corporelle</li>
               </ul>
             </article>
             <article class="offer-process-card" aria-labelledby="offer-card-03-title">
@@ -194,7 +193,7 @@
                 <p class="offer-process-card__kicker">L'application</p>
               </div>
               <h3 class="offer-process-card__title" id="offer-card-03-title">Accès à l'application</h3>
-              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-03-title">
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-03-title">
                 <li>Accès à ton programme</li>
                 <li>Suivi de tes charges</li>
                 <li>Messagerie directe 7/7</li>
@@ -209,7 +208,7 @@
                 <p class="offer-process-card__kicker">Le bilan</p>
               </div>
               <h3 class="offer-process-card__title" id="offer-card-04-title">Appel bilan</h3>
-              <ul class="offres-feature-list offer-process-card__list" aria-labelledby="offer-card-04-title">
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-04-title">
                 <li>1 appel bilan de 45 minutes à la fin des 4 semaines</li>
                 <li>Questionnaire préalablement complété</li>
                 <li>Résumé et recommandations pour la suite</li>
@@ -223,7 +222,7 @@
         <div class="offer-section-inner">
           <p class="eyebrow">Tu te reconnais ?</p>
           <h2 class="offer-section-title" id="offer-for-you-heading">Cette offre est pour toi si…</h2>
-          <ul class="offres-feature-list offer-list-block offres-feature-list--on-plum">
+          <ul class="offer-list-dots offer-list-block">
             <li>Tu t'entraînes déjà, mais tu manques de structure</li>
             <li>Tu veux avoir accès à ton entraîneure pour répondre à toutes tes questions 7 jours sur 7</li>
             <li>Tu es constante depuis plusieurs mois ou années</li>
@@ -238,73 +237,33 @@
           <p class="eyebrow">Comparaison</p>
           <h2 class="offer-section-title" id="offer-compare-heading">Comparer les deux offres</h2>
 
-          <div class="offer-compare" data-offer-compare>
-            <button
-              type="button"
-              class="offer-compare-toggle"
-              data-offer-compare-toggle
-              aria-expanded="false"
-              aria-controls="offer-compare-panel"
-              id="offer-compare-btn"
-            >
-              <span class="offer-compare-toggle__text">Afficher la comparaison</span>
-              <svg
-                class="offer-compare-chevron"
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
+          <div class="offer-compare-columns">
+            <div class="offer-compare-col offer-compare-col--current">
+              <p class="offer-compare-kicker offer-compare-kicker--current">Offre actuelle</p>
+              <h3 class="offer-compare-col-title">Le Tremplin</h3>
+              <p class="offer-compare-col-sub">1 mois</p>
+              <ul class="offres-feature-list offer-compare-list">
+                <li>Tu t'entraînes déjà ou t'es déjà entraînée dans le passé</li>
+                <li>Tu es autonome et déjà constante</li>
+                <li>Tu ne peux pas facilement intégrer du présentiel chaque semaine</li>
+                <li>Tu veux briser un plateau</li>
+              </ul>
+            </div>
+            <div class="offer-compare-col">
+              <p class="offer-compare-kicker">Autre offre</p>
+              <h3 class="offer-compare-col-title">Offre signature</h3>
+              <p class="offer-compare-col-sub">3 mois</p>
+              <ul class="offres-feature-list offer-compare-list">
+                <li>Tu ne t'es jamais entraînée</li>
+                <li>Tu veux une transformation plus complète</li>
+                <li>Tu as besoin de plus d'encadrement</li>
+                <li>Tu veux bénéficier de séances en présentiel</li>
+                <li>Tu veux être suivie de façon plus rapprochée</li>
+                <li>Tu veux installer des habitudes solides sur le long terme</li>
+              </ul>
+              <a class="arrow-text-link offer-compare-other-link" href="/offres/offre-signature"
+                >Voir cette offre<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
               >
-                <path
-                  d="M6 9l6 6 6-6"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
-            <div
-              class="offer-compare-panel-wrap"
-              data-offer-compare-panel-wrap
-              aria-hidden="true"
-              id="offer-compare-panel"
-              role="region"
-              aria-labelledby="offer-compare-btn"
-            >
-              <div class="offer-compare-panel-inner">
-                <div class="offer-compare-columns">
-                  <div class="offer-compare-col offer-compare-col--current">
-                    <p class="offer-compare-kicker offer-compare-kicker--current">Offre actuelle</p>
-                    <h3 class="offer-compare-col-title">Le Tremplin</h3>
-                    <p class="offer-compare-col-sub">1 mois</p>
-                    <ul class="offres-feature-list offer-compare-list">
-                      <li>Tu t'entraînes déjà ou t'es déjà entraînée dans le passé</li>
-                      <li>Tu es autonome et déjà constante</li>
-                      <li>Tu ne peux pas facilement intégrer du présentiel chaque semaine</li>
-                      <li>Tu veux briser un plateau</li>
-                    </ul>
-                  </div>
-                  <div class="offer-compare-col">
-                    <p class="offer-compare-kicker">Autre offre</p>
-                    <h3 class="offer-compare-col-title">Offre signature</h3>
-                    <p class="offer-compare-col-sub">3 mois</p>
-                    <ul class="offres-feature-list offer-compare-list">
-                      <li>Tu ne t'es jamais entraînée</li>
-                      <li>Tu veux une transformation plus complète</li>
-                      <li>Tu as besoin de plus d'encadrement</li>
-                      <li>Tu veux bénéficier de séances en présentiel</li>
-                      <li>Tu veux être suivie de façon plus rapprochée</li>
-                      <li>Tu veux installer des habitudes solides sur le long terme</li>
-                    </ul>
-                    <a class="arrow-text-link offer-compare-other-link" href="/offres/offre-signature"
-                      >Voir cette offre<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
-                    >
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/offres/offre-signature/index.html
+++ b/offres/offre-signature/index.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Une formule de 12 semaines pour transformer ta façon de t'entraîner avec structure, soutien et encadrement serré."
+    />
+    <title>Offre signature — Éliane Larre</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Poppins:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="offer-page">
+    <a class="skip-link" href="#contenu-principal">Passer au contenu</a>
+
+    <header class="site-nav" id="site-nav" data-nav>
+      <a class="nav-logo" href="/#accueil" aria-label="Éliane Larre — Accueil"><em>Éliane Larre</em></a>
+      <nav aria-label="Navigation principale">
+        <ul class="nav-desktop">
+          <li><a href="/#introduction">Introduction</a></li>
+          <li class="nav-dropdown" data-nav-dropdown>
+            <a
+              href="/#offres"
+              class="nav-dropdown-trigger"
+              id="nav-offres-trigger"
+              data-nav-dropdown-trigger
+              aria-expanded="false"
+              aria-haspopup="menu"
+              aria-controls="nav-offres-menu"
+            >
+              Offres
+              <svg
+                class="nav-dropdown-chevron"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M6 9l6 6 6-6"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </a>
+            <div
+              class="nav-dropdown-panel"
+              id="nav-offres-menu"
+              data-nav-dropdown-panel
+              role="menu"
+              aria-labelledby="nav-offres-trigger"
+              hidden
+            >
+              <div class="nav-dropdown-panel__surface">
+                <a href="/offres/le-tremplin" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 1 — Le Tremplin</a
+                >
+                <a href="/offres/offre-signature" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 2 — Offre signature</a
+                >
+              </div>
+            </div>
+          </li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+      </nav>
+      <a
+        class="nav-cta nav-cta--outline"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
+        >Appel découverte</a>
+      <button
+        type="button"
+        class="nav-toggle"
+        aria-expanded="false"
+        aria-controls="nav-mobile"
+        data-nav-toggle
+        aria-label="Ouvrir le menu"
+      >
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+    </header>
+
+    <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
+      <ul>
+        <li><a href="/#introduction" data-nav-link>Introduction</a></li>
+        <li><a href="/#offres" data-nav-link>Offres</a></li>
+        <li><a href="/offres/le-tremplin" data-nav-link>Offre 1 — Le Tremplin</a></li>
+        <li><a href="/offres/offre-signature" data-nav-link>Offre 2 — Offre signature</a></li>
+        <li><a href="/#faq" data-nav-link>FAQ</a></li>
+      </ul>
+      <a
+        class="btn btn-primary nav-mobile-cta"
+        href="https://cal.com/elianelarre/appel-decouverte"
+        data-cal-link="elianelarre/appel-decouverte"
+        data-cal-namespace="appel-decouverte"
+        data-cal-config='{"layout":"month_view"}'
+        data-nav-link
+        >Appel découverte</a
+      >
+    </div>
+
+    <main id="contenu-principal" class="offer-main">
+      <section class="offer-hero">
+        <div class="offer-hero-inner">
+          <p class="offer-hero-eyebrow">Formule 3 mois</p>
+          <h1 class="offer-hero-title">Offre signature</h1>
+          <p class="offer-hero-subtitle">
+            <em>Pour transformer ta façon de t'entraîner avec structure et encadrement serré.</em>
+          </p>
+          <p class="offer-hero-pitch">
+            Une formule de trois mois pensée pour celles qui veulent un accompagnement complet, structuré et personnalisé,
+            avec un encadrement rapproché pour progresser de façon durable. Tu bénéficies d'un suivi et d'une séance en
+            présentiel chaque semaine, d'un programme d'entraînement personnalisé, d'un accès à moi 7/7 par message pendant
+            12 semaines, d'ajustements au besoin, ainsi que d'un accompagnement de proximité pour t'aider à évoluer avec
+            clarté, constance et confiance.
+          </p>
+          <div class="offer-hero-actions">
+            <a
+              class="btn btn-primary"
+              href="https://cal.com/elianelarre/appel-decouverte"
+              data-cal-link="elianelarre/appel-decouverte"
+              data-cal-namespace="appel-decouverte"
+              data-cal-config='{"layout":"month_view"}'
+              >Appel découverte</a
+            >
+            <a class="arrow-text-link offer-hero-secondary" href="#comparaison"
+              >Comparer les offres<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section class="offer-section offer-section--warm-sand" aria-labelledby="offer-ideal-heading">
+        <div class="offer-section-inner">
+          <p class="eyebrow">Pour qui</p>
+          <h2 class="offer-section-title" id="offer-ideal-heading">Cette offre est idéale si tu veux…</h2>
+          <ul class="offres-feature-list offer-list-block">
+            <li>Commencer ou reprendre l'entraînement avec un cadre structuré</li>
+            <li>Être accompagnée de façon rapprochée pendant 12 semaines</li>
+            <li>Avoir un suivi en présentiel chaque semaine</li>
+            <li>Avoir accès à moi 7/7 pour tes questions et ajustements</li>
+            <li>Bénéficier d'un programme personnalisé selon tes objectifs et niveau de départ</li>
+            <li>Installer des habitudes solides et durables</li>
+            <li>Progresser avec plus d'encadrement, de structure et de constance</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="offer-section" aria-labelledby="offer-includes-heading">
+        <div class="offer-section-inner offer-section-inner--wide">
+          <p class="eyebrow">Ce que tu reçois</p>
+          <h2 class="offer-section-title" id="offer-includes-heading">Ce que comprend l'offre</h2>
+          <div class="offer-process-grid">
+            <article class="offer-process-card" aria-labelledby="offer-card-01-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">01</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">La rencontre</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-01-title">Rencontre initiale</h3>
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-01-title">
+                <li>Présentation du programme et ajustements</li>
+                <li>Tests physiques</li>
+                <li>Prises de la composition corporelle</li>
+              </ul>
+            </article>
+            <article class="offer-process-card" aria-labelledby="offer-card-02-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">02</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">Les séances</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-02-title">Séances en présentiel</h3>
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-02-title">
+                <li>12 rencontres en présentiel, à raison de 1 séance par semaine</li>
+                <li>Ajustements du programme au besoin tout au long de l'accompagnement</li>
+              </ul>
+            </article>
+            <article class="offer-process-card" aria-labelledby="offer-card-03-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">03</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">Le programme &amp; l'application</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-03-title">Programme personnalisé</h3>
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-03-title">
+                <li>Programme d'entraînement personnalisé</li>
+                <li>Accès à ton programme via l'application</li>
+                <li>Suivi de tes charges et ta progression</li>
+                <li>Messagerie directe 7/7</li>
+                <li>Questionnaires « check-in de la semaine »</li>
+                <li>Ajustements du programme via tes commentaires et ta progression</li>
+              </ul>
+            </article>
+            <article class="offer-process-card" aria-labelledby="offer-card-04-title">
+              <div class="offer-process-card__head">
+                <span class="offer-process-card__num" aria-hidden="true">04</span>
+                <span class="offer-process-card__rule" aria-hidden="true"></span>
+                <p class="offer-process-card__kicker">La nutrition &amp; le bilan</p>
+              </div>
+              <h3 class="offer-process-card__title" id="offer-card-04-title">Nutrition et suivi personnalisé</h3>
+              <ul class="offer-line-list offer-process-card__list" aria-labelledby="offer-card-04-title">
+                <li>1 semaine de journal alimentaire pour optimiser ton alimentation selon tes objectifs</li>
+                <li>Bilan écrit des observations et conseils adaptés à ta réalité</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="offer-section offer-section--plum" aria-labelledby="offer-for-you-heading">
+        <div class="offer-section-inner">
+          <p class="eyebrow">Tu te reconnais ?</p>
+          <h2 class="offer-section-title" id="offer-for-you-heading">Cette offre te correspond si…</h2>
+          <ul class="offer-list-dots offer-list-block">
+            <li>Tu ne t'es jamais entraînée</li>
+            <li>Tu as une limitation physique</li>
+            <li>Tu veux diminuer les risques de blessures</li>
+            <li>Tu veux une formule plus complète et plus encadrée</li>
+            <li>Tu bénéficies du présentiel régulier pour bien progresser</li>
+            <li>Tu veux être suivie de façon plus rapprochée</li>
+            <li>Tu veux un accompagnement personnalisé avec beaucoup de structure</li>
+            <li>Tu veux développer des bases solides sur plusieurs semaines</li>
+            <li>Tu veux être soutenue dans ta progression, autant dans l'exécution que dans la constance</li>
+            <li>Tu veux investir dans une démarche plus approfondie</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="offer-section" id="comparaison" aria-labelledby="offer-compare-heading">
+        <div class="offer-section-inner">
+          <p class="eyebrow">Comparaison</p>
+          <h2 class="offer-section-title" id="offer-compare-heading">Comparer les deux offres</h2>
+
+          <div class="offer-compare-columns offer-compare-columns--signature-page">
+            <div class="offer-compare-col offer-compare-col--current">
+              <p class="offer-compare-kicker offer-compare-kicker--current">Offre actuelle</p>
+              <h3 class="offer-compare-col-title">Offre signature</h3>
+              <p class="offer-compare-col-sub">3 mois</p>
+              <ul class="offres-feature-list offer-compare-list">
+                <li>Tu ne t'es jamais entraînée</li>
+                <li>Tu veux une transformation plus complète</li>
+                <li>Tu as besoin de plus d'encadrement</li>
+                <li>Tu veux bénéficier de séances en présentiel</li>
+                <li>Tu veux être suivie de façon plus rapprochée</li>
+                <li>Tu veux installer des habitudes solides sur le long terme</li>
+              </ul>
+            </div>
+            <div class="offer-compare-col offer-compare-col--other">
+              <p class="offer-compare-kicker">Autre offre</p>
+              <h3 class="offer-compare-col-title">Le Tremplin</h3>
+              <p class="offer-compare-col-sub">1 mois</p>
+              <ul class="offres-feature-list offer-compare-list">
+                <li>Tu t'entraînes déjà ou t'es déjà entraînée dans le passé</li>
+                <li>Tu es autonome et déjà constante</li>
+                <li>Tu ne peux pas facilement intégrer du présentiel chaque semaine</li>
+                <li>Tu veux briser un plateau</li>
+              </ul>
+              <a class="arrow-text-link offer-compare-other-link" href="/offres/le-tremplin"
+                >Voir cette offre<span class="hero-ghost-arrow" aria-hidden="true">→</span></a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <a
+      class="offer-sticky-cta"
+      href="https://cal.com/elianelarre/appel-decouverte"
+      data-cal-link="elianelarre/appel-decouverte"
+      data-cal-namespace="appel-decouverte"
+      data-cal-config='{"layout":"month_view"}'
+      data-offer-sticky-cta
+      aria-label="Réserver un appel découverte"
+      aria-hidden="true"
+      tabindex="-1"
+      >Commencer maintenant</a
+    >
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
+          <p class="footer-brand"><em>Éliane Larre</em></p>
+          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-location">Montréal, Québec</p>
+        </section>
+
+        <nav class="footer-col footer-col--nav" aria-label="Navigation pied de page">
+          <h3 class="footer-title">Navigation</h3>
+          <ul class="footer-links">
+            <li><a href="/#introduction">Introduction</a></li>
+            <li>
+              <a href="/#offres">Offres</a>
+              <ul class="footer-sublinks">
+                <li><a href="/offres/le-tremplin">Offre 1 — Le Tremplin</a></li>
+                <li><a href="/offres/offre-signature">Offre 2 — Offre signature</a></li>
+              </ul>
+            </li>
+            <li><a href="/#faq">FAQ</a></li>
+            <li>
+              <a
+                href="https://cal.com/elianelarre/appel-decouverte"
+                data-cal-link="elianelarre/appel-decouverte"
+                data-cal-namespace="appel-decouverte"
+                data-cal-config='{"layout":"month_view"}'
+                >Appel découverte</a
+              >
+            </li>
+          </ul>
+        </nav>
+
+        <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
+          <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
+          <address class="footer-contact-list">
+            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a
+              class="footer-ig-link"
+              href="https://www.instagram.com/eliane.au.naturel"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram @elianelarre (nouvel onglet)"
+            >
+              <svg class="footer-ig-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path
+                  d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zm0 10.162a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 11-2.881 0 1.44 1.44 0 012.881 0z"
+                />
+              </svg>
+            </a>
+          </address>
+        </section>
+
+        <nav class="footer-col footer-col--legal" aria-label="Liens légaux">
+          <h3 class="footer-title">Légal</h3>
+          <ul class="footer-links">
+            <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
+            <li><a href="/conditions-utilisation">Conditions d'utilisation</a></li>
+            <li><a href="#" data-cookie-preferences-link>Gérer mes préférences de témoins</a></li>
+          </ul>
+        </nav>
+      </div>
+      <div class="footer-bottom">
+        <p class="footer-bottom-copy">© 2026 Éliane Larre. Tous droits réservés.</p>
+        <p class="footer-bottom-credit">
+          <a href="https://wfwonder.com/" target="_blank" rel="noopener noreferrer">WorkflowWonder ✦</a>
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/politique-de-confidentialite/index.html
+++ b/politique-de-confidentialite/index.html
@@ -25,8 +25,8 @@
         <ul class="nav-desktop">
           <li><a href="/#introduction">Introduction</a></li>
           <li class="nav-dropdown" data-nav-dropdown>
-            <button
-              type="button"
+            <a
+              href="/#offres"
               class="nav-dropdown-trigger"
               id="nav-offres-trigger"
               data-nav-dropdown-trigger
@@ -34,7 +34,7 @@
               aria-haspopup="menu"
               aria-controls="nav-offres-menu"
             >
-              <span class="nav-dropdown-trigger__label">Offres</span>
+              Offres
               <svg
                 class="nav-dropdown-chevron"
                 width="12"
@@ -53,7 +53,7 @@
                   stroke-linejoin="round"
                 />
               </svg>
-            </button>
+            </a>
             <div
               class="nav-dropdown-panel"
               id="nav-offres-menu"
@@ -63,8 +63,12 @@
               hidden
             >
               <div class="nav-dropdown-panel__surface">
-                <a href="/offres/offre-1" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 1</a>
-                <a href="/offres/offre-2" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item>Offre 2</a>
+                <a href="/offres/le-tremplin" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 1 — Le Tremplin</a
+                >
+                <a href="/offres/offre-signature" class="nav-dropdown-link" role="menuitem" data-nav-dropdown-item
+                  >Offre 2 — Offre signature</a
+                >
               </div>
             </div>
           </li>
@@ -93,8 +97,9 @@
     <div class="nav-mobile-panel" id="nav-mobile" data-nav-panel hidden>
       <ul>
         <li><a href="/#introduction" data-nav-link>Introduction</a></li>
-        <li><a href="/offres/offre-1" data-nav-link>Offre 1</a></li>
-        <li><a href="/offres/offre-2" data-nav-link>Offre 2</a></li>
+        <li><a href="/#offres" data-nav-link>Offres</a></li>
+        <li><a href="/offres/le-tremplin" data-nav-link>Offre 1 — Le Tremplin</a></li>
+        <li><a href="/offres/offre-signature" data-nav-link>Offre 2 — Offre signature</a></li>
         <li><a href="/#faq" data-nav-link>FAQ</a></li>
       </ul>
       <a
@@ -242,10 +247,10 @@
           <ul class="footer-links">
             <li><a href="/#introduction">Introduction</a></li>
             <li>
-              <a href="/#programme">Offres</a>
+              <a href="/#offres">Offres</a>
               <ul class="footer-sublinks">
-                <li><a href="/offres/offre-1">Offre 1</a></li>
-                <li><a href="/offres/offre-2">Offre 2</a></li>
+                <li><a href="/offres/le-tremplin">Offre 1 — Le Tremplin</a></li>
+                <li><a href="/offres/offre-signature">Offre 2 — Offre signature</a></li>
               </ul>
             </li>
             <li><a href="/#faq">FAQ</a></li>

--- a/src/main.js
+++ b/src/main.js
@@ -317,25 +317,6 @@ initPresentielStaticMap();
 const faq = document.querySelector('[data-faq]');
 if (faq) initFaq(faq);
 
-/** Collapsible comparison block (offer detail pages). */
-function initOfferCompare() {
-  const root = document.querySelector('[data-offer-compare]');
-  if (!root) return;
-  const btn = root.querySelector('[data-offer-compare-toggle]');
-  const wrap = root.querySelector('[data-offer-compare-panel-wrap]');
-  const textEl = btn?.querySelector('.offer-compare-toggle__text');
-  if (!btn || !wrap || !textEl) return;
-
-  btn.addEventListener('click', () => {
-    const open = !root.classList.contains('is-open');
-    root.classList.toggle('is-open', open);
-    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-    wrap.setAttribute('aria-hidden', open ? 'false' : 'true');
-    wrap.classList.toggle('is-expanded', open);
-    textEl.textContent = open ? 'Masquer la comparaison' : 'Afficher la comparaison';
-  });
-}
-
 /** Sticky discovery CTA: show after scroll threshold; hide when footer is visible. */
 function initOfferStickyCta() {
   const el = document.querySelector('[data-offer-sticky-cta]');
@@ -370,7 +351,6 @@ function initOfferStickyCta() {
   apply();
 }
 
-initOfferCompare();
 initOfferStickyCta();
 
 initCookieConsent();

--- a/src/main.js
+++ b/src/main.js
@@ -317,4 +317,60 @@ initPresentielStaticMap();
 const faq = document.querySelector('[data-faq]');
 if (faq) initFaq(faq);
 
+/** Collapsible comparison block (offer detail pages). */
+function initOfferCompare() {
+  const root = document.querySelector('[data-offer-compare]');
+  if (!root) return;
+  const btn = root.querySelector('[data-offer-compare-toggle]');
+  const wrap = root.querySelector('[data-offer-compare-panel-wrap]');
+  const textEl = btn?.querySelector('.offer-compare-toggle__text');
+  if (!btn || !wrap || !textEl) return;
+
+  btn.addEventListener('click', () => {
+    const open = !root.classList.contains('is-open');
+    root.classList.toggle('is-open', open);
+    btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    wrap.setAttribute('aria-hidden', open ? 'false' : 'true');
+    wrap.classList.toggle('is-expanded', open);
+    textEl.textContent = open ? 'Masquer la comparaison' : 'Afficher la comparaison';
+  });
+}
+
+/** Sticky discovery CTA: show after scroll threshold; hide when footer is visible. */
+function initOfferStickyCta() {
+  const el = document.querySelector('[data-offer-sticky-cta]');
+  const footer = document.querySelector('.site-footer');
+  if (!el || !footer) return;
+
+  const SCROLL_THRESHOLD = 500;
+
+  let footerVisible = false;
+
+  const apply = () => {
+    const scrollPast = window.scrollY > SCROLL_THRESHOLD;
+    const visible = scrollPast && !footerVisible;
+    el.classList.toggle('is-visible', visible);
+    el.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    if (visible) el.removeAttribute('tabindex');
+    else el.setAttribute('tabindex', '-1');
+  };
+
+  window.addEventListener('scroll', apply, { passive: true });
+
+  const io = new IntersectionObserver(
+    (entries) => {
+      const e = entries[0];
+      footerVisible = !!(e && e.isIntersecting);
+      apply();
+    },
+    { threshold: 0, rootMargin: '0px' },
+  );
+  io.observe(footer);
+
+  apply();
+}
+
+initOfferCompare();
+initOfferStickyCta();
+
 initCookieConsent();

--- a/src/main.js
+++ b/src/main.js
@@ -131,13 +131,22 @@ function initNavDesktopDropdowns(nav) {
     });
     root.addEventListener('mouseleave', scheduleCloseFromPointerLeave);
 
+    const triggerIsLink = trigger.tagName === 'A';
+
     trigger.addEventListener('click', (e) => {
+      if (triggerIsLink) {
+        close();
+        return;
+      }
       e.stopPropagation();
       if (isExpanded()) close();
       else open();
     });
 
     trigger.addEventListener('keydown', (e) => {
+      if (triggerIsLink && (e.key === ' ' || e.key === 'Spacebar')) {
+        return;
+      }
       if (e.key === ' ' || e.key === 'Spacebar') {
         e.preventDefault();
         if (isExpanded()) close();

--- a/src/style.css
+++ b/src/style.css
@@ -2935,23 +2935,6 @@ cal-modal-box * {
   margin: 0 auto;
 }
 
-.offer-back-link {
-  display: inline-block;
-  margin-bottom: 1.75rem;
-  font-size: 0.8125rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: var(--muted);
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 0.18em;
-  transition: color 0.2s ease;
-}
-
-.offer-back-link:hover {
-  color: var(--plum);
-}
-
 .offer-hero-eyebrow {
   margin: 0 0 1.15rem;
   font-size: 0.6875rem;
@@ -3029,12 +3012,33 @@ cal-modal-box * {
   color: #fff8f5;
 }
 
-.offer-section--plum .offres-feature-list--on-plum li {
+.offer-section--plum .offer-list-dots {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.offer-section--plum .offer-list-dots li {
+  position: relative;
+  margin: 0;
+  padding-left: 1.15rem;
+  font-size: 1rem;
+  line-height: 1.55;
   color: rgba(255, 248, 245, 0.94);
 }
 
-.offer-section--plum .offres-feature-list--on-plum li::before {
-  background-color: var(--gold);
+.offer-section--plum .offer-list-dots li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.52em;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--gold);
 }
 
 .offer-section-inner {
@@ -3148,78 +3152,34 @@ cal-modal-box * {
 .offer-process-card__list {
   flex: 1 1 auto;
   margin: 0;
-  gap: 0.6rem;
 }
 
-.offer-compare {
-  margin-top: 0.5rem;
-}
-
-.offer-compare-toggle {
-  width: 100%;
+.offer-line-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 0.65rem;
+  border-left: 2px solid rgba(85, 39, 114, 0.65);
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
-  font-family: var(--font-sans);
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.offer-line-list li {
+  margin: 0;
+  padding-left: 0.8rem;
   font-size: 0.9375rem;
-  font-weight: 400;
-  text-align: left;
-  color: var(--ink);
-  background: var(--white);
-  border: 1px solid rgba(26, 20, 16, 0.1);
-  border-radius: 8px;
-  cursor: pointer;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
+  line-height: 1.55;
+  color: var(--mid);
 }
 
-.offer-compare-toggle:hover {
-  border-color: rgba(85, 39, 114, 0.25);
-  box-shadow: 0 4px 16px rgba(26, 20, 16, 0.05);
-}
-
-.offer-compare-toggle:focus-visible {
-  outline: 2px solid var(--plum);
-  outline-offset: 3px;
-}
-
-.offer-compare-toggle__text {
-  flex: 1;
-  min-width: 0;
-}
-
-.offer-compare-chevron {
-  flex-shrink: 0;
-  color: var(--plum);
-  transition: transform 300ms ease;
-}
-
-[data-offer-compare].is-open .offer-compare-chevron {
-  transform: rotate(180deg);
-}
-
-.offer-compare-panel-wrap {
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 300ms ease;
-  margin-top: 0.75rem;
-}
-
-.offer-compare-panel-wrap.is-expanded {
-  grid-template-rows: 1fr;
-}
-
-.offer-compare-panel-inner {
-  overflow: hidden;
-  min-height: 0;
+.offer-line-list li::before {
+  content: none;
 }
 
 .offer-compare-columns {
   display: grid;
   gap: 1.5rem;
+  margin-top: 0.5rem;
   padding: 0.25rem 0 0.5rem;
 }
 
@@ -3337,14 +3297,6 @@ cal-modal-box * {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .offer-compare-panel-wrap {
-    transition: none;
-  }
-
-  .offer-compare-chevron {
-    transition: none;
-  }
-
   .offer-sticky-cta {
     transition:
       opacity 0.15s ease,
@@ -3365,9 +3317,5 @@ cal-modal-box * {
 
   .offer-sticky-cta.is-visible {
     transform: none;
-  }
-
-  [data-offer-compare].is-open .offer-compare-chevron {
-    transform: rotate(180deg);
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -2917,3 +2917,372 @@ cal-modal-box * {
 [data-cal-namespace="appel-decouverte"]:not(a):not(button) {
   z-index: 99999 !important;
 }
+
+/* —— Offer detail pages (e.g. Le Tremplin) —— */
+.offer-main {
+  padding-top: calc(var(--nav-h) + clamp(2.5rem, 5vw, 4rem));
+}
+
+.offer-hero {
+  padding: clamp(1.5rem, 4vw, 2.75rem) var(--pad-x) clamp(4.5rem, 10vw, 6rem);
+  background: var(--beige);
+}
+
+.offer-hero-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.offer-back-link {
+  display: inline-block;
+  margin-bottom: 1.75rem;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--muted);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+  transition: color 0.2s ease;
+}
+
+.offer-back-link:hover {
+  color: var(--plum);
+}
+
+.offer-hero-eyebrow {
+  margin: 0 0 1.15rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--plum);
+}
+
+.offer-hero-title {
+  font-family: var(--font-serif);
+  font-size: clamp(2.5rem, 4.8vw, 4.25rem);
+  font-weight: 400;
+  line-height: 1.08;
+  color: var(--ink);
+  margin: 0 0 1rem;
+}
+
+.offer-hero-subtitle {
+  margin: 0 0 1.5rem;
+  font-family: var(--font-serif);
+  font-size: clamp(1.35rem, 2.4vw, 1.85rem);
+  font-weight: 400;
+  line-height: 1.35;
+  color: var(--plum);
+}
+
+.offer-hero-subtitle em {
+  font-style: italic;
+  color: var(--plum);
+}
+
+.offer-hero-pitch {
+  margin: 0 0 2rem;
+  max-width: 720px;
+  font-size: 1.0625rem;
+  line-height: 1.85;
+  color: var(--mid);
+}
+
+.offer-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.25rem 1.75rem;
+}
+
+.offer-hero-secondary {
+  font-size: clamp(0.9375rem, 0.35vw + 0.9rem, 1rem);
+}
+
+.offer-section {
+  padding: clamp(3.5rem, 8vw, 5.5rem) var(--pad-x);
+  background: var(--beige);
+}
+
+.offer-section--muted {
+  background: var(--white);
+}
+
+.offer-section-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.offer-section-inner--wide {
+  max-width: 52rem;
+}
+
+.offer-section .eyebrow {
+  margin-bottom: 1rem;
+}
+
+.offer-section-title {
+  font-family: var(--font-serif);
+  font-size: clamp(1.85rem, 3vw, 2.75rem);
+  font-weight: 400;
+  line-height: 1.15;
+  color: var(--ink);
+  margin: 0 0 1.5rem;
+}
+
+.offer-list-block {
+  margin-top: 0.25rem;
+}
+
+#comparaison {
+  scroll-margin-top: calc(var(--nav-h) + 1rem);
+}
+
+.offer-includes-grid {
+  display: grid;
+  gap: 2.25rem;
+  margin-top: 0.5rem;
+}
+
+@media (min-width: 900px) {
+  .offer-includes-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 2.5rem 3rem;
+  }
+}
+
+.offer-include-label {
+  margin: 0 0 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--mid);
+}
+
+.offer-include-group .offres-feature-list {
+  gap: 0.65rem;
+}
+
+.offer-compare {
+  margin-top: 0.5rem;
+}
+
+.offer-compare-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  font-weight: 400;
+  text-align: left;
+  color: var(--ink);
+  background: var(--white);
+  border: 1px solid rgba(26, 20, 16, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.offer-compare-toggle:hover {
+  border-color: rgba(85, 39, 114, 0.25);
+  box-shadow: 0 4px 16px rgba(26, 20, 16, 0.05);
+}
+
+.offer-compare-toggle:focus-visible {
+  outline: 2px solid var(--plum);
+  outline-offset: 3px;
+}
+
+.offer-compare-toggle__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.offer-compare-chevron {
+  flex-shrink: 0;
+  color: var(--plum);
+  transition: transform 300ms ease;
+}
+
+[data-offer-compare].is-open .offer-compare-chevron {
+  transform: rotate(180deg);
+}
+
+.offer-compare-panel-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 300ms ease;
+  margin-top: 0.75rem;
+}
+
+.offer-compare-panel-wrap.is-expanded {
+  grid-template-rows: 1fr;
+}
+
+.offer-compare-panel-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.offer-compare-columns {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0.25rem 0 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .offer-compare-columns {
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+  }
+}
+
+.offer-compare-col {
+  padding: 1.5rem 1.35rem;
+  border-radius: clamp(12px, 1.5vw, 16px);
+  border: 1px solid rgba(90, 80, 72, 0.14);
+  background: #faf7f3;
+}
+
+.offer-compare-col--current {
+  border-color: rgba(85, 39, 114, 0.35);
+  background: linear-gradient(180deg, rgba(85, 39, 114, 0.08) 0%, #faf7f3 45%);
+  box-shadow: 0 4px 20px rgba(85, 39, 114, 0.08);
+}
+
+.offer-compare-kicker {
+  margin: 0 0 0.65rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.offer-compare-kicker--current {
+  color: var(--plum);
+}
+
+.offer-compare-col-title {
+  font-family: var(--font-serif);
+  font-size: 1.35rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--ink);
+  margin: 0 0 0.35rem;
+}
+
+.offer-compare-col-sub {
+  margin: 0 0 1rem;
+  font-size: 0.8125rem;
+  font-style: italic;
+  color: rgba(90, 80, 72, 0.8);
+}
+
+.offer-compare-list {
+  margin-bottom: 0;
+}
+
+.offer-compare-other-link {
+  display: inline-flex;
+  margin-top: 1.25rem;
+}
+
+.offer-sticky-cta {
+  position: fixed;
+  right: clamp(1.25rem, 4vw, 2rem);
+  bottom: clamp(1.25rem, 4vw, 2rem);
+  z-index: 480;
+  visibility: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  max-width: calc(100vw - 2.5rem);
+  padding: clamp(0.75rem, 2.2vw, 1.05rem) clamp(1.35rem, 3.5vw, 1.85rem);
+  font-family: var(--font-sans);
+  font-size: clamp(0.5625rem, 1.5vw, 0.625rem);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--white);
+  background: var(--plum);
+  border-radius: 999px;
+  border: none;
+  box-shadow: 0 8px 28px rgba(85, 39, 114, 0.28);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(20px);
+  pointer-events: none;
+  transition:
+    opacity 300ms ease,
+    transform 300ms ease,
+    visibility 0s linear 300ms,
+    background 0.25s ease;
+}
+
+.offer-sticky-cta:hover {
+  background: var(--plum-hover);
+}
+
+.offer-sticky-cta:focus-visible {
+  outline: 2px solid var(--plum);
+  outline-offset: 3px;
+}
+
+.offer-sticky-cta.is-visible {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  transition:
+    opacity 300ms ease,
+    transform 300ms ease,
+    visibility 0s linear 0s,
+    background 0.25s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .offer-compare-panel-wrap {
+    transition: none;
+  }
+
+  .offer-compare-chevron {
+    transition: none;
+  }
+
+  .offer-sticky-cta {
+    transition:
+      opacity 0.15s ease,
+      visibility 0s linear 0.15s,
+      background 0.25s ease;
+  }
+
+  .offer-sticky-cta.is-visible {
+    transition:
+      opacity 0.15s ease,
+      visibility 0s linear 0s,
+      background 0.25s ease;
+  }
+
+  .offer-sticky-cta:not(.is-visible) {
+    transform: none;
+  }
+
+  .offer-sticky-cta.is-visible {
+    transform: none;
+  }
+
+  [data-offer-compare].is-open .offer-compare-chevron {
+    transform: rotate(180deg);
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -3188,6 +3188,15 @@ cal-modal-box * {
     grid-template-columns: 1fr 1fr;
     gap: 1.5rem;
   }
+
+  /* Offre signature page: DOM = current first for mobile; desktop = Tremplin left, Signature right */
+  .offer-compare-columns--signature-page .offer-compare-col--other {
+    order: 1;
+  }
+
+  .offer-compare-columns--signature-page .offer-compare-col--current {
+    order: 2;
+  }
 }
 
 .offer-compare-col {

--- a/src/style.css
+++ b/src/style.css
@@ -19,6 +19,8 @@
   --radius-sm: 4px;
   --shadow-cta: 0 12px 32px rgba(85, 39, 114, 0.2);
   --nav-h: 4.5rem;
+  /* Offer detail: warm band between cream sections (sand / latte) */
+  --offer-warm-sand: #e8dfd4;
 }
 
 *,
@@ -3010,6 +3012,31 @@ cal-modal-box * {
   background: var(--white);
 }
 
+.offer-section--warm-sand {
+  background: var(--offer-warm-sand);
+}
+
+.offer-section--plum {
+  background: var(--plum);
+}
+
+.offer-section--plum .eyebrow {
+  color: var(--gold);
+  font-weight: 600;
+}
+
+.offer-section--plum .offer-section-title {
+  color: #fff8f5;
+}
+
+.offer-section--plum .offres-feature-list--on-plum li {
+  color: rgba(255, 248, 245, 0.94);
+}
+
+.offer-section--plum .offres-feature-list--on-plum li::before {
+  background-color: var(--gold);
+}
+
 .offer-section-inner {
   max-width: 720px;
   margin: 0 auto;
@@ -3040,30 +3067,88 @@ cal-modal-box * {
   scroll-margin-top: calc(var(--nav-h) + 1rem);
 }
 
-.offer-includes-grid {
+.offer-process-grid {
   display: grid;
-  gap: 2.25rem;
+  gap: 1.5rem;
   margin-top: 0.5rem;
+  align-items: stretch;
 }
 
-@media (min-width: 900px) {
-  .offer-includes-grid {
+@media (min-width: 768px) {
+  .offer-process-grid {
     grid-template-columns: 1fr 1fr;
-    gap: 2.5rem 3rem;
+    gap: clamp(1.35rem, 2.5vw, 2rem);
   }
 }
 
-.offer-include-label {
-  margin: 0 0 0.75rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--mid);
+@media (min-width: 1024px) {
+  .offer-process-grid {
+    gap: clamp(1.5rem, 3vw, 2rem);
+  }
 }
 
-.offer-include-group .offres-feature-list {
-  gap: 0.65rem;
+.offer-process-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+  border-radius: clamp(14px, 1.5vw, 16px);
+  background: var(--white);
+  box-shadow: 0 6px 26px rgba(26, 20, 16, 0.08);
+  padding: clamp(1.75rem, 3vw, 2rem) clamp(1.65rem, 3vw, 2.25rem);
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .offer-process-card {
+    padding: 1.65rem 1.5rem;
+  }
+}
+
+.offer-process-card__head {
+  margin-bottom: 0.35rem;
+}
+
+.offer-process-card__num {
+  display: block;
+  font-family: var(--font-serif);
+  font-size: clamp(2.75rem, 5.5vw, 4rem);
+  font-weight: 400;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  color: var(--plum);
+}
+
+.offer-process-card__rule {
+  display: block;
+  width: clamp(2.5rem, 8vw, 3.75rem);
+  height: 1px;
+  margin: 0.65rem 0 0.75rem;
+  background: var(--gold);
+}
+
+.offer-process-card__kicker {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.offer-process-card__title {
+  margin: 0 0 1rem;
+  font-family: var(--font-serif);
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+.offer-process-card__list {
+  flex: 1 1 auto;
+  margin: 0;
+  gap: 0.6rem;
 }
 
 .offer-compare {

--- a/src/style.css
+++ b/src/style.css
@@ -178,6 +178,7 @@ button:focus-visible {
   align-items: center;
   gap: 0.25rem;
   transition: color 0.2s;
+  text-decoration: none;
 }
 
 .nav-dropdown-trigger__label {
@@ -206,7 +207,7 @@ button:focus-visible {
   top: 100%;
   left: 50%;
   z-index: 520;
-  min-width: 11rem;
+  min-width: 15.5rem;
   padding-top: 0.35rem;
   transform: translateX(-50%) translateY(-6px);
   opacity: 0;
@@ -243,10 +244,11 @@ button:focus-visible {
   box-sizing: border-box;
   padding: 10px 20px;
   font-family: var(--font-serif);
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   font-weight: 400;
   letter-spacing: 0.02em;
   text-transform: none;
+  line-height: 1.35;
   color: var(--mid);
   transition:
     color 0.15s ease,
@@ -436,6 +438,14 @@ button:focus-visible {
   background: var(--plum-hover);
   transform: translateY(-2px);
   box-shadow: var(--shadow-cta);
+}
+
+.btn--offres-cta {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.85rem 1.25rem;
+  font-size: 0.625rem;
+  letter-spacing: 0.12em;
 }
 
 .btn-gold {
@@ -2197,178 +2207,259 @@ button:focus-visible {
   margin-top: clamp(3rem, 5vw, 4rem);
 }
 
-/* —— Programme —— */
-.programme-head {
-  display: grid;
-  grid-template-columns: 1fr 200px;
-  gap: 2rem;
-  align-items: end;
-  margin-bottom: 2.5rem;
+/* —— Offres (homepage) —— */
+.section-inner--offres {
+  max-width: 68rem;
 }
 
-.programme-head .media-frame {
-  aspect-ratio: 3 / 4;
+.section-offres {
+  padding-top: clamp(5rem, 10vw, 6rem);
+  padding-bottom: clamp(5rem, 10vw, 6rem);
 }
 
-.prog-steps {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  background: rgba(26, 20, 16, 0.06);
+.offres-head {
+  max-width: 40rem;
+  margin-bottom: clamp(2.5rem, 5vw, 3.5rem);
 }
 
-.prog-step {
-  display: grid;
-  grid-template-columns: minmax(200px, 240px) 1fr;
-  gap: 0;
-  background: var(--white);
+.offres-head h2 {
+  margin-bottom: 1rem;
 }
 
-.prog-side {
-  padding: 2.25rem 1.75rem;
-  border-right: 1px solid rgba(26, 20, 16, 0.06);
+.offres-lead {
+  margin: 0;
+  font-size: 1.0625rem;
+  line-height: 1.75;
+  color: var(--muted);
+  max-width: 36rem;
 }
 
-.prog-tag {
-  font-size: 0.625rem;
-  font-weight: 500;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--plum);
-  margin-bottom: 0.5rem;
-}
-
-.prog-step h3 {
-  font-family: var(--font-serif);
-  font-size: 1.25rem;
-  font-weight: 600;
-  line-height: 1.25;
-  color: var(--ink);
-}
-
-.prog-body {
-  padding: 2.25rem 2rem;
-}
-
-.prog-body > p {
-  font-size: 0.9375rem;
-  line-height: 1.8;
-  color: var(--mid);
-  margin-bottom: 1.25rem;
-}
-
-.prog-list {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.prog-list li {
-  font-size: 0.875rem;
-  line-height: 1.5;
-  color: var(--mid);
-  display: flex;
-  gap: 0.65rem;
-}
-
-.prog-list li::before {
-  content: '—';
-  color: var(--gold);
-  flex-shrink: 0;
-}
-
-@media (max-width: 800px) {
-  .programme-head {
-    grid-template-columns: 1fr;
-  }
-
-  .programme-head .media-frame {
-    max-width: 280px;
-  }
-
-  .prog-step {
-    grid-template-columns: 1fr;
-  }
-
-  .prog-side {
-    border-right: none;
-    border-bottom: 1px solid rgba(26, 20, 16, 0.06);
-  }
-}
-
-/* —— Inclus —— */
-.inclus-layout {
+.offres-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 2.5rem;
-  align-items: start;
-  margin-bottom: 2.5rem;
+  gap: 1.5rem;
+  align-items: stretch;
 }
 
-.media-frame--inclus-banner img {
-  /* Portrait source in 21:9: keep face + forearms on bar centered in crop */
-  object-position: 50% 42%;
+.offres-card--tremplin {
+  order: 2;
 }
 
-.incl-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
+.offres-card--signature {
+  order: 1;
+}
+
+@media (min-width: 768px) {
+  .offres-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: clamp(1.5rem, 3vw, 2rem);
+  }
+
+  .offres-card--tremplin {
+    order: 1;
+  }
+
+  .offres-card--signature {
+    order: 2;
+  }
+}
+
+@media (min-width: 1024px) {
+  .offres-grid {
+    gap: clamp(2rem, 3vw, 3rem);
+  }
+}
+
+.offres-card {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  border-radius: clamp(14px, 1.5vw, 18px);
+  border: 1px solid rgba(90, 80, 72, 0.14);
+  background: #faf7f3;
+  box-shadow: 0 6px 28px rgba(26, 20, 16, 0.06);
+}
+
+.offres-card--signature {
+  background: linear-gradient(180deg, rgba(85, 39, 114, 0.07) 0%, #faf7f3 42%);
+  border-color: rgba(85, 39, 114, 0.2);
+}
+
+.offres-badge {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1;
+  font-family: var(--font-sans);
+  font-size: 0.5625rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.offres-badge--muted {
+  color: rgba(90, 80, 72, 0.62);
+  background: rgba(246, 241, 234, 0.95);
+  border: 1px solid rgba(90, 80, 72, 0.12);
+  padding: 0.35rem 0.55rem;
+  border-radius: 4px;
+  letter-spacing: 0.12em;
+}
+
+.offres-badge--popular {
+  top: 0.4rem;
+  right: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  color: var(--white);
+  background: var(--plum);
+  box-shadow: 0 4px 14px rgba(85, 39, 114, 0.28);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  transform: translate(8%, -35%);
+  pointer-events: none;
+}
+
+.offres-card__body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
   gap: 0;
-  border: 1px solid rgba(26, 20, 16, 0.08);
+  min-width: 0;
+  padding-right: 0.25rem;
 }
 
-.incl-item {
-  padding: 1.75rem 1.5rem;
-  border-bottom: 1px solid rgba(26, 20, 16, 0.08);
-  border-right: 1px solid rgba(26, 20, 16, 0.08);
-  background: var(--white);
-  transition: background 0.2s;
-}
-
-.incl-item:nth-child(2n) {
-  border-right: none;
-}
-
-.incl-item:hover {
-  background: var(--beige);
-}
-
-.incl-n {
+.offres-card__title {
   font-family: var(--font-serif);
-  font-size: 0.8125rem;
-  color: var(--gold);
-  margin-bottom: 0.5rem;
-}
-
-.incl-item h3 {
-  font-size: 0.9375rem;
-  font-weight: 500;
+  font-size: clamp(1.25rem, 2vw, 1.5rem);
+  font-weight: 600;
+  line-height: 1.2;
   color: var(--ink);
-  margin-bottom: 0.35rem;
+  margin: 0 0 0.35rem;
 }
 
-.incl-item p {
-  font-size: 0.8125rem;
-  line-height: 1.65;
+.offres-card__duration {
+  margin: 0 0 1rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-style: italic;
+  color: rgba(90, 80, 72, 0.72);
+}
+
+.offres-card__pitch {
+  margin: 0 0 1.25rem;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--mid);
+  max-width: 26rem;
+}
+
+.offres-feature-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.offres-feature-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  font-size: 0.9375rem;
+  line-height: 1.55;
   color: var(--mid);
 }
 
-@media (max-width: 800px) {
-  .inclus-layout {
-    grid-template-columns: 1fr;
-  }
+.offres-feature-list li::before {
+  content: '';
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.38rem;
+  background-color: var(--plum);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%23000' d='M13.78 4.22a.75.75 0 0 1 0 1.06l-6.5 6.5a.75.75 0 0 1-1.06 0L2.22 7.78a.75.75 0 1 1 1.06-1.06L6.5 10l5.72-5.72a.75.75 0 0 1 1.06 0z'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%23000' d='M13.78 4.22a.75.75 0 0 1 0 1.06l-6.5 6.5a.75.75 0 0 1-1.06 0L2.22 7.78a.75.75 0 1 1 1.06-1.06L6.5 10l5.72-5.72a.75.75 0 0 1 1.06 0z'/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}
 
-  .incl-grid {
-    grid-template-columns: 1fr;
-  }
+.offres-ideal {
+  margin-top: 1.35rem;
+  padding-top: 1.15rem;
+  border-top: 1px solid rgba(26, 20, 16, 0.08);
+}
 
-  .incl-item {
-    border-right: 1px solid rgba(26, 20, 16, 0.08);
-  }
+.offres-ideal__label {
+  margin: 0 0 0.35rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: rgba(90, 80, 72, 0.65);
+}
 
-  .incl-item:nth-child(2n) {
-    border-right: 1px solid rgba(26, 20, 16, 0.08);
+.offres-ideal__text {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: var(--mid);
+}
+
+.offres-card__cta {
+  margin-top: auto;
+  padding-top: 1.5rem;
+}
+
+.offres-helper {
+  margin-top: clamp(3rem, 5vw, 4rem);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 32rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.offres-helper__line {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(1.05rem, 1.8vw, 1.2rem);
+  font-style: italic;
+  font-weight: 400;
+  color: rgba(90, 80, 72, 0.85);
+}
+
+.offres-helper__sub {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--mid);
+}
+
+.offres-helper .btn-primary {
+  margin-top: 0.35rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .offres-badge--popular {
+    transform: none;
+    top: 0.65rem;
+    right: 0.65rem;
   }
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ const TRAILING_SLASH_REDIRECT_ROUTES = [
   '/politique-de-confidentialite',
   '/conditions-utilisation',
   '/offres/le-tremplin',
+  '/offres/offre-signature',
 ];
 
 function trailingSlashRedirectPlugin() {
@@ -48,6 +49,7 @@ export default defineConfig({
         politiqueDeConfidentialite: resolve(__dirname, 'politique-de-confidentialite/index.html'),
         conditionsUtilisation: resolve(__dirname, 'conditions-utilisation/index.html'),
         offresLeTremplin: resolve(__dirname, 'offres/le-tremplin/index.html'),
+        offresOffreSignature: resolve(__dirname, 'offres/offre-signature/index.html'),
       },
       output: {
         manualChunks: undefined,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,18 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 
-const LEGAL_ROUTES = ['/politique-de-confidentialite', '/conditions-utilisation'];
+const TRAILING_SLASH_REDIRECT_ROUTES = [
+  '/politique-de-confidentialite',
+  '/conditions-utilisation',
+  '/offres/le-tremplin',
+];
 
-function cleanRouteRedirectPlugin() {
+function trailingSlashRedirectPlugin() {
   const redirect = (middlewares) => {
     middlewares.use((req, res, next) => {
       if (!req.url) return next();
       const path = req.url.split('?')[0];
-      if (LEGAL_ROUTES.includes(path)) {
+      if (TRAILING_SLASH_REDIRECT_ROUTES.includes(path)) {
         res.statusCode = 302;
         res.setHeader('Location', `${path}/`);
         res.end();
@@ -19,7 +23,7 @@ function cleanRouteRedirectPlugin() {
   };
 
   return {
-    name: 'legal-clean-route-redirect',
+    name: 'trailing-slash-route-redirect',
     configureServer(server) {
       redirect(server.middlewares);
     },
@@ -31,7 +35,7 @@ function cleanRouteRedirectPlugin() {
 
 export default defineConfig({
   appType: 'mpa',
-  plugins: [cleanRouteRedirectPlugin()],
+  plugins: [trailingSlashRedirectPlugin()],
   root: '.',
   publicDir: 'public',
   build: {
@@ -43,6 +47,7 @@ export default defineConfig({
         main: resolve(__dirname, 'index.html'),
         politiqueDeConfidentialite: resolve(__dirname, 'politique-de-confidentialite/index.html'),
         conditionsUtilisation: resolve(__dirname, 'conditions-utilisation/index.html'),
+        offresLeTremplin: resolve(__dirname, 'offres/le-tremplin/index.html'),
       },
       output: {
         manualChunks: undefined,


### PR DESCRIPTION
Closes #39

## Summary
- Removed draft sections **Le programme en détail** and **Ce qui est inclus** (and their scoped CSS).
- Added **`#offres`** section between poids libres and the purple CTA band: two offer cards (Le Tremplin / Offre signature), helper block with discovery CTA, responsive grid with **Offre signature first on mobile**.
- **Nav:** Offres is an anchor (`#offres` on home, `/#offres` on legal pages); hover still opens dropdown; dropdown labels and URLs updated to `/offres/le-tremplin` and `/offres/offre-signature`.
- **Hero:** secondary link → *Voir les offres* → `#offres`.
- **Footer:** Offres parent + sublinks aligned with nav.
- **JS:** dropdown click toggles only for non-link triggers; link triggers close menu on navigate.

## How to verify
- `npm run build` (passes locally).
- Manual: home — scroll/layout desktop &lt;768 / 768–1023 / ≥1024; nav hover + click Offres; mobile menu; footer links; hero ghost link; legal pages Offres → `/#offres`.
- Detail URLs 404 until follow-up (expected).

## Notes
- No secrets in PR.