### PR TITLE
chore(site): contact email + footer tagline

### DIFF
--- a/conditions-utilisation/index.html
+++ b/conditions-utilisation/index.html
@@ -190,7 +190,7 @@
 
           <h2>10. Nous contacter</h2>
           <p>Pour toute question concernant ces conditions, tu peux me contacter à :</p>
-          <p><a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a></p>
+          <p><a href="mailto:info@elianelarre.com">info@elianelarre.com</a></p>
 
           <p class="legal-note">
             <em
@@ -208,7 +208,7 @@
       <div class="footer-inner">
         <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
           <p class="footer-brand"><em>Éliane Larre</em></p>
-          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-tagline">Entraîneure personnelle</p>
           <p class="footer-location">Montréal, Québec</p>
         </section>
 
@@ -239,7 +239,7 @@
         <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
           <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
           <address class="footer-contact-list">
-            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a href="mailto:info@elianelarre.com">info@elianelarre.com</a>
             <a
               class="footer-ig-link"
               href="https://www.instagram.com/eliane.au.naturel"

--- a/index.html
+++ b/index.html
@@ -967,7 +967,7 @@
                   Pour toute question sur l'accompagnement, les offres ou la logistique, n'hésite pas. Je réponds
                   personnellement.
                 </p>
-                <a class="faq-contact-email" href="mailto:elianelarre@hotmail.com">elianelarre@hotmail.com</a>
+                <a class="faq-contact-email" href="mailto:info@elianelarre.com">info@elianelarre.com</a>
                 <div class="faq-contact-sep" role="presentation"></div>
                 <p class="faq-contact-or">ou</p>
                 <a
@@ -1125,7 +1125,7 @@
       <div class="footer-inner">
         <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
           <p class="footer-brand"><em>Éliane Larre</em></p>
-          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-tagline">Entraîneure personnelle</p>
           <p class="footer-location">Montréal, Québec</p>
         </section>
 
@@ -1156,7 +1156,7 @@
         <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
           <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
           <address class="footer-contact-list">
-            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a href="mailto:info@elianelarre.com">info@elianelarre.com</a>
             <a
               class="footer-ig-link"
               href="https://www.instagram.com/eliane.au.naturel"

--- a/offres/le-tremplin/index.html
+++ b/offres/le-tremplin/index.html
@@ -288,7 +288,7 @@
       <div class="footer-inner">
         <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
           <p class="footer-brand"><em>Éliane Larre</em></p>
-          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-tagline">Entraîneure personnelle</p>
           <p class="footer-location">Montréal, Québec</p>
         </section>
 
@@ -319,7 +319,7 @@
         <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
           <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
           <address class="footer-contact-list">
-            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a href="mailto:info@elianelarre.com">info@elianelarre.com</a>
             <a
               class="footer-ig-link"
               href="https://www.instagram.com/eliane.au.naturel"

--- a/offres/offre-signature/index.html
+++ b/offres/offre-signature/index.html
@@ -297,7 +297,7 @@
       <div class="footer-inner">
         <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
           <p class="footer-brand"><em>Éliane Larre</em></p>
-          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-tagline">Entraîneure personnelle</p>
           <p class="footer-location">Montréal, Québec</p>
         </section>
 
@@ -328,7 +328,7 @@
         <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
           <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
           <address class="footer-contact-list">
-            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a href="mailto:info@elianelarre.com">info@elianelarre.com</a>
             <a
               class="footer-ig-link"
               href="https://www.instagram.com/eliane.au.naturel"

--- a/politique-de-confidentialite/index.html
+++ b/politique-de-confidentialite/index.html
@@ -182,7 +182,7 @@
             <li>De retirer ton consentement au traitement de tes données</li>
             <li>De porter plainte auprès de la Commission d'accès à l'information du Québec</li>
           </ul>
-          <p>Pour exercer ces droits, communique avec moi à l'adresse : contact@eliane-larre.com</p>
+          <p>Pour exercer ces droits, communique avec moi à l'adresse : info@elianelarre.com</p>
 
           <h2>6. Témoins (cookies)</h2>
           <p>
@@ -221,7 +221,7 @@
 
           <h2>9. Nous contacter</h2>
           <p>Pour toute question concernant cette politique de confidentialité, tu peux me contacter à :</p>
-          <p><a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a></p>
+          <p><a href="mailto:info@elianelarre.com">info@elianelarre.com</a></p>
 
           <p class="legal-note">
             <em
@@ -239,7 +239,7 @@
       <div class="footer-inner">
         <section class="footer-col footer-col--brand" aria-label="Marque Éliane Larre">
           <p class="footer-brand"><em>Éliane Larre</em></p>
-          <p class="footer-tagline">Entraîneure personnelle privée</p>
+          <p class="footer-tagline">Entraîneure personnelle</p>
           <p class="footer-location">Montréal, Québec</p>
         </section>
 
@@ -270,7 +270,7 @@
         <section class="footer-col footer-col--contact" aria-labelledby="footer-contact-heading">
           <h3 class="footer-title" id="footer-contact-heading">Contact</h3>
           <address class="footer-contact-list">
-            <a href="mailto:contact@eliane-larre.com">contact@eliane-larre.com</a>
+            <a href="mailto:info@elianelarre.com">info@elianelarre.com</a>
             <a
               class="footer-ig-link"
               href="https://www.instagram.com/eliane.au.naturel"


### PR DESCRIPTION
## Summary
- Replace public contact addresses with **info@elianelarre.com** everywhere they appeared (`contact@eliane-larre.com`, `elianelaree@hotmail.com`): all footers, legal pages, offer pages, FAQ mailto on homepage.
- Footer tagline: **Entraîneure personnelle** (removed “privée”) on all pages with the shared footer pattern.

## Verification
- `rg -i "eliane-larre|hotmail|contact@eliane"` — no matches for old contact strings in HTML.
- Spot-check: footer + FAQ contact link + politique / conditions mailto in browser (optional).

Closes #47