### PR TITLE
fix(cal): iOS Safari embed preload and ready queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
       href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Poppins:wght@300;400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link rel="preconnect" href="https://app.cal.com" crossorigin />
+    <link rel="preconnect" href="https://cal.com" crossorigin />
+    <link rel="preload" as="script" href="https://app.cal.com/embed/embed.js" crossorigin />
     <script type="module" src="/src/main.js"></script>
   </head>
   <body>

--- a/src/cal-embed.js
+++ b/src/cal-embed.js
@@ -8,6 +8,64 @@ const CAL_NAMESPACE = "appel-decouverte";
 /** Viewports below this use Cal `column_view`; at or above use `month_view`. */
 const CAL_LAYOUT_BREAKPOINT_PX = 768;
 
+const CAL_EMBED_LOAD_FALLBACK_MS = 8000;
+
+/** @type {ReturnType<typeof setTimeout> | null} */
+let calEmbedFallbackTimer = null;
+
+/**
+ * @typedef {{ el: HTMLElement, calLink: string, namespace: string, config: Record<string, unknown> }} CalModalIntent
+ */
+
+/** @type {CalModalIntent[]} */
+let pendingCalModals = [];
+
+function clearCalEmbedFallbackTimer() {
+  if (calEmbedFallbackTimer != null) {
+    clearTimeout(calEmbedFallbackTimer);
+    calEmbedFallbackTimer = null;
+  }
+}
+
+function drainPendingCalModalQueue() {
+  if (pendingCalModals.length === 0) return;
+  const items = pendingCalModals;
+  pendingCalModals = [];
+  items.forEach(({ el }) => el.classList.remove("is-cal-loading"));
+
+  const last = items[items.length - 1];
+  const api = window.Cal?.ns?.[last.namespace];
+  if (typeof api === "function") {
+    api("modal", { calLink: last.calLink, config: last.config });
+  }
+}
+
+function scheduleCalEmbedFallback() {
+  if (calEmbedFallbackTimer != null) return;
+  calEmbedFallbackTimer = window.setTimeout(() => {
+    calEmbedFallbackTimer = null;
+    if (window.__ELIANE_CAL_EMBED_READY__) return;
+
+    const items = pendingCalModals;
+    pendingCalModals = [];
+    items.forEach(({ el }) => el.classList.remove("is-cal-loading"));
+
+    const last = items[items.length - 1];
+    if (last?.el instanceof HTMLAnchorElement && last.el.href) {
+      window.location.href = last.el.href;
+    }
+  }, CAL_EMBED_LOAD_FALLBACK_MS);
+}
+
+/**
+ * @param {CalModalIntent} intent
+ */
+function enqueuePendingCalModal(intent) {
+  pendingCalModals.push(intent);
+  intent.el.classList.add("is-cal-loading");
+  scheduleCalEmbedFallback();
+}
+
 function installCalQueueSnippet() {
   const C = window;
   const A = CAL_EMBED_SRC;
@@ -24,7 +82,15 @@ function installCalQueueSnippet() {
       if (!cal.loaded) {
         cal.ns = {};
         cal.q = cal.q || [];
-        d.head.appendChild(d.createElement("script")).src = A;
+        const scriptEl = d.createElement("script");
+        scriptEl.src = A;
+        scriptEl.crossOrigin = "";
+        scriptEl.addEventListener("load", () => {
+          window.__ELIANE_CAL_EMBED_READY__ = true;
+          clearCalEmbedFallbackTimer();
+          drainPendingCalModalQueue();
+        });
+        d.head.appendChild(scriptEl);
         cal.loaded = true;
       }
       if (ar[0] === L) {
@@ -80,6 +146,7 @@ function buildCalUiConfig() {
 
 if (!window.__ELIANE_CAL_EMBED_INIT__) {
   window.__ELIANE_CAL_EMBED_INIT__ = true;
+  window.__ELIANE_CAL_EMBED_READY__ = false;
   installCalQueueSnippet();
   window.Cal("init", CAL_NAMESPACE, { origin: "https://cal.com" });
   const ns = window.Cal.ns[CAL_NAMESPACE];
@@ -142,10 +209,17 @@ function bindCalModalClickHandlers() {
           layout: resolveCalModalLayout(),
         };
 
-        const api = window.Cal?.ns?.[namespace];
-        if (typeof api !== "function") return;
+        const intent = { el, calLink, namespace, config };
 
-        api("modal", { calLink, config });
+        if (window.__ELIANE_CAL_EMBED_READY__) {
+          const api = window.Cal?.ns?.[namespace];
+          if (typeof api === "function") {
+            api("modal", { calLink, config });
+          }
+          return;
+        }
+
+        enqueuePendingCalModal(intent);
       },
       false,
     );

--- a/src/style.css
+++ b/src/style.css
@@ -3107,6 +3107,12 @@ button:focus-visible {
 
 }
 
+/* —— Cal.com CTA: embed script still loading (iOS Safari race guard) —— */
+.is-cal-loading {
+  opacity: 0.65;
+  cursor: wait;
+}
+
 /* —— Cal.com embed modal —— above fixed .site-nav (z-index: 500) and nav dropdown (520) */
 cal-modal-box,
 cal-modal-box * {


### PR DESCRIPTION
## Summary
- **index.html:** `preconnect` to `app.cal.com` and `cal.com`, `preload` `embed.js` before Vite module (homepage early fetch).
- **cal-embed.js:** `__ELIANE_CAL_EMBED_READY__` on script `load`; queue early clicks with `.is-cal-loading`; 8s fallback to `window.location.href` on last queued anchor.
- **style.css:** `.is-cal-loading` visual cue.

## How verified
- Logic review; linter clean on `cal-embed.js`. Maintainer to confirm on iOS Safari + Fast 3G.

Closes #49